### PR TITLE
fix: Improve `SubmitMultiResult` using callbacks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,15 @@ linters:
       checks:
         - all
         - -ST1000
+    forbidigo:
+      forbid:
+        - pattern: ^print(ln)?$|^fmt\.Print(|f|ln)$
+          msg: print statements should not be committed
+        - pattern: ^context.Context.Err$
+          msg: >-
+            using context.Context.Err() directly shadows cause, instead use
+            context.Cause()
+      analyze-types: true
   exclusions:
     generated: lax
     rules:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It enforces best practices for context propagation, error handling, and resource
 The API will change frequently as we refine the design and functionality.
 Expect new features and improvements in future releases, generators and work pools are just the beginning.
 
-![Go Version](https://img.shields.io/badge/go-1.19-blue) ![License](https://img.shields.io/badge/license-MIT-green)
+![Go Version](https://img.shields.io/badge/go-1.20-blue) ![License](https://img.shields.io/badge/license-MIT-green)
 
 ## Features
 

--- a/api/pool/pool.go
+++ b/api/pool/pool.go
@@ -82,9 +82,9 @@ func (p *pool[PoolResourceT]) Close() {
 // Submit implements [types.Pool.Submit].
 func (p *pool[PoolResourceT]) Submit(ctx context.Context, task types.ValuelessTask[PoolResourceT]) error {
 	// select is not deterministic, and may still send tasks even if the context has been canceled.
-	if ctx.Err() != nil {
+	if err := context.Cause(ctx); err != nil {
 		//nolint:wrapcheck
-		return ctx.Err()
+		return err
 	}
 
 	ctxTask := contextualTask[PoolResourceT]{
@@ -96,7 +96,7 @@ func (p *pool[PoolResourceT]) Submit(ctx context.Context, task types.ValuelessTa
 	select {
 	case <-ctx.Done():
 		//nolint:wrapcheck
-		return ctx.Err()
+		return context.Cause(ctx)
 	case p.requests <- ctxTask:
 		return nil
 	}

--- a/api/pool/pool_test.go
+++ b/api/pool/pool_test.go
@@ -60,7 +60,7 @@ func TestPoolSubmitAfterClose(t *testing.T) {
 }
 
 func TestPoolContextCancel(t *testing.T) {
-	p := NewPool[any](nil, 1)
+	p := NewPoolBuffered[any](nil, 1, 0)
 	p.Start()
 	defer p.Close()
 

--- a/api/pool/task.go
+++ b/api/pool/task.go
@@ -2,7 +2,6 @@ package pool
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/Izzette/go-safeconcurrency/api/results"
 	"github.com/Izzette/go-safeconcurrency/api/types"
@@ -23,12 +22,13 @@ func TaskWrapper[PoolResourceT any, ValueT any](
 	task types.Task[PoolResourceT, ValueT],
 ) (types.ValuelessTask[PoolResourceT], types.TaskResult[ValueT]) {
 	res := make(chan ValueT, 1)
-	errPtr := &atomic.Pointer[error]{}
+	// taskResult.err and wrappedTask.err must point to the same error variable.
+	var err error
 	taskResult := &taskResult[ValueT]{
 		results: res,
-		err:     errPtr,
+		err:     &err,
 	}
-	wrappedTask := &taskWrapper[PoolResourceT, ValueT]{task, res, errPtr}
+	wrappedTask := &taskWrapper[PoolResourceT, ValueT]{task, res, &err}
 
 	return wrappedTask, taskResult
 }
@@ -38,75 +38,44 @@ func TaskWrapper[PoolResourceT any, ValueT any](
 // The buffer size of the results channel is specified by the buffer parameter.
 // It is recommended avoid using a buffer size of 0, as this will block the worker until the result is received.
 //
-// It is recommended to defer a call to [types.TaskResult.Drain] on the results channel immediately after the task is
-// submitted to avoid blocking the worker pool if all results are not consumed.
-// Alternatively, canceling the [context.Context] passed to the task will also stop the [types.Pool] from blocking.
-// If the [context.Context] passed to [types.Pool.Submit] is canceled before the task is finished, the task will
-// not produce any results and the result channel will be closed.
-//
-// For example:
-//
-//	// Wrap the MultiResultTask in a ValuelessTask with WrapMultiResultTask.
-//	valuelessTask, taskResult := pool.WrapMultiResultTaskBuffered(multiResultTask, 1)
-//
-//	// Submit the task to the pool, check for errors (context cancellation).
-//	if err := pool.Submit(ctx, valuelessTask); err != nil {
-//		return err
-//	}
-//	// Defer a call to .Drain() to avoid blocking the worker pool in the case that all results are not consumed.
-//	defer taskResult.Drain()
-//
-//	// Consume the results channel.
-//	for value := range taskResult.Results() {
-//		Do(value)
-//	}
-//
-//	// If the task returns an error, it will be available in .Err() after the results channel is closed.
-//	if err := taskResult.Err(); err != nil {
-//		return err
-//	}
-//
-// There exists a [SubmitMultiResult] helper function that wraps the task and submits it to the pool, waiting for the
-// results and returning them as a slice.
-// However, this does not provide a mechanism to process the results as they are produced, thus making it only as
-// effective as using [types.Task] and returning a single sclice as the result.
-// [SubmitMultiResult] is however useful for testing, debugging, and demonstration purposes where the performance
-// difference is unimportant.
+// It is recommended not to use this wrapper directly, but rather use the [SubmitMultiResultBuffered] helper function.
+// The [SubmitMultiResultBuffered] helper will wrap the [types.MultiResultTask], submit it to the pool, and call the
+// callback for each result as it is produced.
+// The [SubmitMultiResultBuffered] helper implements error handling correctly and is less error prone than using
+// this wrapper and calling [types.Pool.Submit] directly.
 func WrapMultiResultTaskBuffered[PoolResourceT any, ValueT any](
 	task types.MultiResultTask[PoolResourceT, ValueT],
 	buffer uint,
 ) (types.ValuelessTask[PoolResourceT], types.TaskResult[ValueT]) {
 	res := make(chan ValueT, buffer)
 	handle := results.NewHandle(res)
-	errPtr := &atomic.Pointer[error]{}
+	var err error
 	taskResult := &taskResult[ValueT]{
 		results: res,
-		err:     errPtr,
+		err:     &err,
 	}
 	wrappedTask := multiResultTaskWrapper[PoolResourceT, ValueT]{
 		task:   task,
 		handle: handle,
-		err:    errPtr,
+		err:    &err,
 	}
 
 	return wrappedTask, taskResult
 }
 
-// WrapMultiResultTask wraps a [types.MultiResultTask] with no results buffering.
-// As there is no buffering, this will block the worker until all the results are received.
-// If you would like results buffering, use [WrapMultiResultTaskBuffered] instead.
-// This is equivalent to calling [WrapMultiResultTaskBuffered] with a buffer size of 0.
+// WrapMultiResultTask wraps a [types.MultiResultTask] with a buffer size of 1.
+// This is equivalent to calling [WrapMultiResultTaskBuffered] with a buffer size of 1.
 func WrapMultiResultTask[PoolResourceT any, ValueT any](
 	task types.MultiResultTask[PoolResourceT, ValueT],
 ) (types.ValuelessTask[PoolResourceT], types.TaskResult[ValueT]) {
-	return WrapMultiResultTaskBuffered(task, 0)
+	return WrapMultiResultTaskBuffered(task, 1)
 }
 
 // taskResult implements [types.TaskResult].
 // It is used to wrap the results channel and error handling for tasks that return results.
 type taskResult[ValueT any] struct {
 	results <-chan ValueT
-	err     *atomic.Pointer[error]
+	err     *error
 }
 
 // Results implements [types.TaskResult.Results].
@@ -120,38 +89,29 @@ func (tr *taskResult[ValueT]) Drain() error {
 		// drain the results channel
 	}
 
-	return tr.Err()
-}
-
-// Err implements [types.TaskResult.Err].
-func (tr *taskResult[ValueT]) Err() error {
-	if err := tr.err.Load(); err != nil {
-		return *err
-	}
-
-	return nil
+	// err should only be used after the results channel is closed.
+	return *tr.err
 }
 
 // multiResultTaskWrapper is a wrapper for a [types.MultiResultTask] implementing [types.ValuelessTask].
 type multiResultTaskWrapper[PoolResourceT any, ValueT any] struct {
 	task   types.MultiResultTask[PoolResourceT, ValueT]
 	handle types.Handle[ValueT]
-	err    *atomic.Pointer[error]
+	err    *error
 }
 
 // Execute implements [types.MultiResultTask.Execute].
 func (t multiResultTaskWrapper[PoolResourceT, ValueT]) Execute(ctx context.Context, resource PoolResourceT) {
 	defer t.handle.Close()
-	if err := t.task.Execute(ctx, resource, t.handle); err != nil {
-		t.err.Store(&err)
-	}
+	// We must not overwrite the error pointer, but instead store the error at the address of the pointer.
+	*t.err = t.task.Execute(ctx, resource, t.handle)
 }
 
 // taskWrapper is a wrapper for a [types.Task] implementing [types.ValuelessTask].
 type taskWrapper[PoolResourceT any, ValueT any] struct {
 	task types.Task[PoolResourceT, ValueT]
-	r    chan ValueT
-	err  *atomic.Pointer[error]
+	r    chan<- ValueT
+	err  *error
 }
 
 // Execute implements [types.ValuelessTask.Execute].
@@ -162,9 +122,9 @@ func (t taskWrapper[PoolResourceT, ValueT]) Execute(
 	defer close(t.r)
 	// taskWithHandleWrapper will close the handle for us when the task is done.
 	value, err := t.task.Execute(ctx, resource)
+	// We must not overwrite the error pointer, but instead store the error at the address of the pointer.
+	*t.err = err
+
 	// As the results channel is always buffered, we can publish the result without blocking the worker.
 	t.r <- value
-	if err != nil {
-		t.err.Store(&err)
-	}
 }

--- a/api/pool/task_test.go
+++ b/api/pool/task_test.go
@@ -35,7 +35,7 @@ func TestWrapMultiResultTask(t *testing.T) {
 	} else if results[0] != "test" {
 		t.Errorf("Expected 'test', got '%s'", results[0])
 	}
-	if err := taskResult.Err(); err != nil {
+	if err := taskResult.Drain(); err != nil {
 		t.Errorf("Unexpected error from taskResult: %v", err)
 	}
 }
@@ -67,7 +67,7 @@ func TestTaskWrapper(t *testing.T) {
 	} else if val != 42 {
 		t.Errorf("Unexpected result: %v", val)
 	}
-	if err := taskResult.Err(); err != nil {
+	if err := taskResult.Drain(); err != nil {
 		t.Errorf("Unexpected error from taskResult: %v", err)
 	}
 

--- a/api/pool/util.go
+++ b/api/pool/util.go
@@ -2,7 +2,10 @@ package pool
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/Izzette/go-safeconcurrency/api/results"
 	"github.com/Izzette/go-safeconcurrency/api/types"
 )
 
@@ -31,7 +34,8 @@ func Submit[PoolResourceT any, ValueT any](
 		return zero, ctx.Err()
 	case result := <-taskResults.Results():
 		// Before using the (possibly nil) result, check if the task produced an error.
-		if err := taskResults.Err(); err != nil {
+		// We must drain the results channel to ensure that the err is set correctly.
+		if err := taskResults.Drain(); err != nil {
 			//nolint:wrapcheck
 			return zero, err
 		}
@@ -40,63 +44,131 @@ func Submit[PoolResourceT any, ValueT any](
 	}
 }
 
-// SubmitMultiResult is a helper function to submit a [types.MultiResultTask] to a [types.Pool] and wait for the
-// results.
-// It uses a buffer size of 1 for the results channel, to avoid blocking the worker while reading the results.
-// The results slice is initialized with an expected capacity of 0, this may not be very efficient if the task produces
-// a lot of results.
-// If the task returns an error, the results slice returned will be nil.
+// SubmitMultiResultBuffered is a helper function to submit a [types.MultiResultTask] to a [types.Pool] and runs the
+// callback for each result as it is produced.
+//
+// # Callback
+//
+// If the callback produces an error, the task will be canceled and the error will be returned.
+// If the special error [results.Stop] is be returned from the callback the task context will be canceled, the results
+// channel drained, and the callback will not be called again.
+// As both the callback and the task may return an error, the errors will be joined and returned, therefore always
+// make sure to use [errors.Is] and [errors.As] to check for errors returned from this function.
+//
+// # Buffering
+//
+// The buffer size of the results channel is specified by the buffer parameter.
+// It is recommended to avoid using a buffer size of 0, as this will block the worker until the result is received.
+//
+// # Other
 //
 // If you need more control, use [WrapMultiResultTaskBuffered] and call [types.Pool.Submit] directly.
-// [SubmitMultiResult] useful for testing, debugging, and demonstration purposes where the performance difference is
-// unimportant and the ability to consume the results as they are produced is not required.
-func SubmitMultiResult[PoolResourceT any, ValueT any](
+func SubmitMultiResultBuffered[PoolResourceT any, ValueT any](
 	ctx context.Context,
 	pool types.Pool[PoolResourceT],
 	task types.MultiResultTask[PoolResourceT, ValueT],
-) ([]ValueT, error) {
+	buffer uint,
+	callback types.TaskCallback[ValueT],
+) error {
 	// Wrap the task in a ValuelessTask to be able to submit it to the pool.
-	valuelessTask, taskResults := WrapMultiResultTaskBuffered[PoolResourceT](task, 1)
+	valuelessTask, taskResults := WrapMultiResultTaskBuffered[PoolResourceT](task, buffer)
+
+	// Only drain the results channel if the task was submitted successfully.
+	// We should always have already drained the results channel below, but this is a
+	// precaution to avoid deadlocks in the case a panic occurs and recovered by the caller.
+	submitted := false
+	defer func() {
+		if submitted {
+			_ = taskResults.Drain()
+		}
+	}()
+
+	// Ensure the context is canceled when the function returns, before the deference to drain.
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(context.Canceled)
 
 	// Submit the task to the pool.
 	// If context is canceled before the task is published it will instead return an error.
 	if err := pool.Submit(ctx, valuelessTask); err != nil {
 		//nolint:wrapcheck
-		return nil, err
+		return err
 	}
-	// Only drain the results channel if the task was submitted successfully.
-	// We should always have already drained the results channel below, but this is a
-	// precaution to avoid deadlocks.
-	defer func() {
-		_ = taskResults.Drain()
-	}()
+	submitted = true
 
-	results, err := collectTaskResults(ctx, taskResults.Results())
-	if err != nil {
-		//nolint:wrapcheck
-		return nil, err
-	} else if err := taskResults.Err(); err != nil {
-		//nolint:wrapcheck
+	// Call the callback for each result as it is produced.
+	callbackErr := callbackTaskResults(ctx, taskResults.Results(), callback)
+	if callbackErr != nil {
+		// The callback an error, which means we should cancel the task and stop processing results.
+		cancel(fmt.Errorf("callback error %w caused %w", callbackErr, context.Canceled))
+	}
+	taskErr := taskResults.Drain()
+
+	// The special error results.Stop ought not to be returned.
+	if err := errors.Join(callbackErr, taskErr); !errors.Is(err, results.Stop) {
+		return err
+	}
+
+	return nil
+}
+
+// SubmitMultiResult is a helper function to submit a [types.MultiResultTask] to a [types.Pool] and runs the
+// callback for each result as it is produced.
+// It is equivalent to calling [SubmitMultiResultBuffered] with a buffer size of 1.
+// If you would like results buffering, use [SubmitMultiResultBuffered] instead.
+// See [SubmitMultiResultBuffered] for more details.
+func SubmitMultiResult[PoolResourceT any, ValueT any](
+	ctx context.Context,
+	pool types.Pool[PoolResourceT],
+	task types.MultiResultTask[PoolResourceT, ValueT],
+	callback types.TaskCallback[ValueT],
+) error {
+	return SubmitMultiResultBuffered(ctx, pool, task, 1, callback)
+}
+
+// SubmitMultiResultCollectAll is a helper function to submit a [types.MultiResultTask] to a [types.Pool] and collects
+// all results to a slice.
+// It uses a buffer size of 1 for the results channel to minimize blocking the worker while reading the results.
+// The results slice is initialized with an expected capacity of 0, this may not be very efficient if the task produces
+// a lot of results.
+// If the task returns an error, the results slice returned will be nil.
+// SubmitMultiResultCollectAll useful for testing, debugging, and demonstration purposes where the performance
+// difference is unimportant and the ability to consume the results as they are produced is not required.
+// You should most likely use [SubmitMultiResult] instead.
+func SubmitMultiResultCollectAll[PoolResourceT any, ValueT any](
+	ctx context.Context,
+	pool types.Pool[PoolResourceT],
+	task types.MultiResultTask[PoolResourceT, ValueT],
+) ([]ValueT, error) {
+	results := make([]ValueT, 0)
+	if err := SubmitMultiResult(ctx, pool, task, func(ctx context.Context, value ValueT) error {
+		results = append(results, value)
+
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
 	return results, nil
 }
 
-// collectTaskResults collects the results from the taskResults channel until it is closed or the context is canceled.
-func collectTaskResults[ValueT any](ctx context.Context, resultsChan <-chan ValueT) ([]ValueT, error) {
-	results := make([]ValueT, 0)
+// callbackTaskResults consumes the results channel and calls the callback for each result.
+func callbackTaskResults[ValueT any](
+	ctx context.Context, resultsChan <-chan ValueT, callback types.TaskCallback[ValueT],
+) error {
 	for {
 		select {
 		case <-ctx.Done():
 			//nolint:wrapcheck
-			return nil, ctx.Err()
+			return ctx.Err()
 		case result, ok := <-resultsChan:
 			if !ok {
 				// The results channel is closed, we are done.
-				return results, nil
+				return nil
+			} else if err := callback(ctx, result); err != nil {
+				// The callback returned an error, we should stop processing results.
+				//nolint:wrapcheck
+				return err
 			}
-			results = append(results, result)
 		}
 	}
 }

--- a/api/pool/util_test.go
+++ b/api/pool/util_test.go
@@ -185,7 +185,7 @@ func (t *mockMultiResultTaskBlocksOnContext) Execute(ctx context.Context, _ inte
 	t.broadcastPublish()
 	<-ctx.Done()
 
-	return ctx.Err()
+	return context.Cause(ctx)
 }
 
 func (t *mockMultiResultTaskBlocksOnContext) broadcastPublish() {

--- a/api/pool/util_test.go
+++ b/api/pool/util_test.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/Izzette/go-safeconcurrency/api/results"
 	"github.com/Izzette/go-safeconcurrency/api/types"
 )
 
@@ -124,7 +125,7 @@ func TestSubmitMultiResultSuccess(t *testing.T) {
 
 	expected := []string{"a", "b", "c"}
 	task := &mockMultiResultTask2{values: expected}
-	results, err := SubmitMultiResult[any, string](ctx, p, task)
+	results, err := SubmitMultiResultCollectAll[any, string](ctx, p, task)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -141,9 +142,28 @@ func TestSubmitMultiResultTaskError(t *testing.T) {
 
 	expectedErr := errors.New("task error")
 	task := &mockMultiResultTask2{err: expectedErr}
-	_, err := SubmitMultiResult[any, string](ctx, p, task)
+	_, err := SubmitMultiResultCollectAll[any, string](ctx, p, task)
 	if !errors.Is(err, expectedErr) {
 		t.Errorf("Expected error %v, got %v", expectedErr, err)
+	}
+}
+
+func TestSubmitMultiResultEarlyContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately to simulate early cancellation.
+	cancel()
+
+	p := NewPool[any](nil, 1)
+	p.Start()
+	defer p.Close()
+
+	task := &mockMultiResultTask{t}
+	results, err := SubmitMultiResultCollectAll[any, string](ctx, p, task)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected context.Canceled, got %v", err)
+	}
+	if results != nil {
+		t.Errorf("Expected nil results, got %v", results)
 	}
 }
 
@@ -195,11 +215,101 @@ func TestSubmitMultiResultContextCancelled(t *testing.T) {
 		cancel()
 	}()
 
-	_, err := SubmitMultiResult[any, string](ctx, p, task)
+	_, err := SubmitMultiResultCollectAll[any, string](ctx, p, task)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Expected context.Canceled, got %v", err)
 	}
 	if v := task.publishedCount.Load(); v != 1 {
 		t.Errorf("Expected %d values to be published, got %d", len(task.values), v)
+	}
+}
+
+func TestSubmitMultiResultStop(t *testing.T) {
+	ctx := context.Background()
+	p := NewPool[any](nil, 1)
+	p.Start()
+	defer p.Close()
+
+	task := &mockMultiResultTask2{values: []string{"a", "b", "c"}}
+	values := make([]string, 0)
+	err := SubmitMultiResultBuffered[any, string](ctx, p, task, 0, func(ctx context.Context, value string) error {
+		values = append(values, value)
+		if value == "b" {
+			return results.Stop
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expected := []string{"a", "b"}
+	if !reflect.DeepEqual(values, expected) {
+		t.Errorf("Expected %v, got %v", expected, values)
+	}
+}
+
+func TestSubmitMultiResultBothErrors(t *testing.T) {
+	ctx := context.Background()
+	p := NewPool[any](nil, 1)
+	p.Start()
+	defer p.Close()
+
+	taskErr := errors.New("task error")
+	callbackErr := errors.New("callback error")
+	task := &mockMultiResultTask2{values: []string{"a", "b", "c"}, err: taskErr}
+	values := make([]string, 0)
+	err := SubmitMultiResult[any, string](ctx, p, task, func(ctx context.Context, value string) error {
+		values = append(values, value)
+		// Ensure the callback error is only after all the values are processed.
+		if value == "c" {
+			return callbackErr
+		}
+
+		return nil
+	})
+	if err == nil {
+		t.Fatal("Expected non-nil error")
+	}
+	// Check if the error is a join error and contains both task and callback errors.
+	if !errors.Is(err, taskErr) || !errors.Is(err, callbackErr) {
+		t.Errorf("Expected task error %v and callback error %v, got %v", taskErr, callbackErr, err)
+	}
+
+	// Make sure that returning any error will not continue to process results.
+	expected := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(values, expected) {
+		t.Errorf("Expected %v, got %v", expected, values)
+	}
+}
+
+func TestSubmitMultiResultContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := NewPool[any](nil, 1)
+	p.Start()
+	defer p.Close()
+
+	task := &mockMultiResultTask2{values: []string{"a", "b", "c"}}
+	values := make([]string, 0)
+	err := SubmitMultiResultBuffered[any, string](ctx, p, task, 0, func(ctx context.Context, value string) error {
+		values = append(values, value)
+		if value == "b" {
+			// Cancel the context to simulate a cancelation in-flight.
+			cancel()
+			// Do not return an error here, as we want to test the behavior of the context cancelation.
+			return nil
+		}
+
+		return nil
+	})
+	if err == nil {
+		t.Fatal("Expected non-nil error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected context.Canceled, got %v", err)
+	}
+	expected := []string{"a", "b"}
+	if !reflect.DeepEqual(values, expected) {
+		t.Errorf("Expected %v, got %v", expected, values)
 	}
 }

--- a/api/results/base.go
+++ b/api/results/base.go
@@ -23,7 +23,7 @@ type handle[T any] struct {
 func (h *handle[T]) Publish(ctx context.Context, value T) error {
 	// The `select` statement is non-deterministic, and may still publish a result even if the context has been canceled
 	// before Publish is called.
-	if err := ctx.Err(); err != nil {
+	if err := context.Cause(ctx); err != nil {
 		//nolint:wrapcheck
 		return err
 	}
@@ -31,7 +31,7 @@ func (h *handle[T]) Publish(ctx context.Context, value T) error {
 	select {
 	case <-ctx.Done():
 		//nolint:wrapcheck
-		return ctx.Err()
+		return context.Cause(ctx)
 	case h.results <- value:
 		return nil
 	}

--- a/api/results/errors.go
+++ b/api/results/errors.go
@@ -1,0 +1,20 @@
+package results
+
+// Stop is a special error that can be returned from the [github.com/Izzette/go-safeconcurrency/api/types.TaskCallback]
+// to stop processing results.
+//
+//nolint:errname
+const Stop = constantError("stop")
+
+// constantError is a custom error type that can be used to create constant errors.
+type constantError string
+
+// Error implements the error interface for constantError.
+func (e constantError) Error() string {
+	return string(e)
+}
+
+// Unwrap implements the error interface for constantError.
+func (e constantError) Unwrap() error {
+	return nil
+}

--- a/api/results/errors_test.go
+++ b/api/results/errors_test.go
@@ -1,0 +1,23 @@
+package results
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStopError(t *testing.T) {
+	// Check the error message.
+	expectedMsg := "stop"
+	if Stop.Error() != expectedMsg {
+		t.Errorf("expected %q, got %q", expectedMsg, Stop.Error())
+	}
+
+	// Check the Unwrap method.
+	if errors.Unwrap(Stop) != nil {
+		t.Error("expected nil unwrapped error")
+	}
+
+	if !errors.Is(Stop, Stop) {
+		t.Error("This would be rather silly if it didn't work")
+	}
+}

--- a/api/types/pool.go
+++ b/api/types/pool.go
@@ -66,12 +66,12 @@ type TaskResult[ValueT any] interface {
 	Results() <-chan ValueT
 
 	// Drain waits the task to complete and drains the results channel, the results are not returned.
-	// This is useful if you just want to wait for the task to complete.
-	// It returns TaskResult.Err after draining the results channel.
+	// It returns the error produced by the task, if any.
+	// It is safe to call this method as many times as needed to access the error and will never block after the first call
+	// to Drain returns.
 	Drain() error
-
-	// Err returns the error returned by the task.
-	// If the context is canceled, this will return the context error.
-	// If the task is not finished or was successful, this will return nil.
-	Err() error
 }
+
+// TaskCallback is a callback used by [github.com/Izzette/go-safeconcurrency/api/pool.SubmitMultiResult] to process the
+// results of a [types.MultiValueTask] as they are produced.
+type TaskCallback[ValueT any] func(context.Context, ValueT) error

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Izzette/go-safeconcurrency
 
-go 1.19
+go 1.20


### PR DESCRIPTION
* `SubmitMultiResult` now takes a callback, and with `SubmitMultiResultBuffered`
  it has a configurable buffer.
* Upgrade to Go version 1.20+ for `errors.Join` and `context.WithCancelCause`.
* Remove `types.TaskResult.Err()`, as `.Drain()` should always be called
  instead.
