### PR TITLE
fix: de-clutter GoDoc for work pools

### DIFF
--- a/api/types/workpool.go
+++ b/api/types/workpool.go
@@ -3,9 +3,9 @@ package types
 import "context"
 
 // Pool is a worker pool that executes arbitrary tasks concurrently.
-// PoolResourceT is the type of resource used by the pool (ex. API client), it may be set to type any if a shared pool
+// ResourceT is the type of resource used by the pool (ex. API client), it may be set to type any if a shared pool
 // resource is not required.
-type Pool[PoolResourceT any] interface {
+type Pool[ResourceT any] interface {
 	// Start initializes the pool and prepares it for task execution.
 	Start()
 
@@ -21,29 +21,29 @@ type Pool[PoolResourceT any] interface {
 	// Alternatively using context.WithCancel and deferring a call to the context.CancelFunc will stop the task from
 	// blocking the Pool if the caller is no longer interested in the result.
 	// ⚠️You must never attempt to submit tasks to a pool which has been closed, this will result in a panic!
-	Submit(context.Context, ValuelessTask[PoolResourceT]) error
+	Submit(context.Context, ValuelessTask[ResourceT]) error
 }
 
 // Task is a simple task representing a unit of work that can be execution in a [Pool].
 // Task produces a single value result, and an error.
 // The task may be submitted to a [Pool] using [github.com/Izzette/go-safeconcurrency/workpool.Submit].
-// PoolResourceT is the same type as the resource used by the [Pool].
+// ResourceT is the same type as the resource used by the [Pool].
 // ValueT is the type of value(s) produced by the task.
 // If you do not need to return a value but only an error, you can simply set ValueT to any and return nil from the
 // task.
-type Task[PoolResourceT any, ValueT any] interface {
+type Task[ResourceT any, ValueT any] interface {
 	// Execute runs the task with the pool resource and returns the result.
-	Execute(context.Context, PoolResourceT) (ValueT, error)
+	Execute(context.Context, ResourceT) (ValueT, error)
 }
 
 // MultiResultTask represents a unit of work that can be executed in a [Pool].
 // MultiResultTask can be submitted to a [Pool] using
 // [github.com/Izzette/go-safeconcurrency/workpool.SubmitMultiResult].
-// PoolResourceT is the same type as the resource used by the [Pool].
+// ResourceT is the same type as the resource used by the [Pool].
 // ValueT is the type of value(s) produced by the task.
-type MultiResultTask[PoolResourceT any, ValueT any] interface {
+type MultiResultTask[ResourceT any, ValueT any] interface {
 	// Execute runs the task with the pool resource and publishes results to the provided handle.
-	Execute(context.Context, PoolResourceT, Handle[ValueT]) error
+	Execute(context.Context, ResourceT, Handle[ValueT]) error
 }
 
 // ValuelessTask is a minimal version of Task that does not produce results.
@@ -53,14 +53,14 @@ type MultiResultTask[PoolResourceT any, ValueT any] interface {
 // [github.com/Izzette/go-safeconcurrency/workpool.SubmitMultiResult] for information on this functionality.
 // You are not expected to implement this interface directly, but rather use the provided helpers to wrap and submit
 // tasks.
-type ValuelessTask[PoolResourceT any] interface {
+type ValuelessTask[ResourceT any] interface {
 	// Execute runs the task with the pool resource.
-	Execute(context.Context, PoolResourceT)
+	Execute(context.Context, ResourceT)
 }
 
 // TaskFunc can be passed to [github.com/Izzette/go-safeconcurrency/workpool.SubmitFunc] to execute the function as a
 // task.
-type TaskFunc[PoolResourceT any] func(context.Context, PoolResourceT) error
+type TaskFunc[ResourceT any] func(context.Context, ResourceT) error
 
 // TaskResult is the result of a task execution.
 // It is used to propagate results and recoverable errors from the task to the caller.

--- a/workpool/task/task.go
+++ b/workpool/task/task.go
@@ -1,4 +1,4 @@
-package workpool
+package task
 
 import (
 	"context"
@@ -14,10 +14,10 @@ import (
 // If the [context.Context] passed to [types.Pool.Submit] is canceled before the task is finished, the task will
 // not produce any results and the result channel will be closed.
 //
-// It is recommended not to use this wrapper directly, but rather use the [Submit] helper function.
-// The [Submit] helper will wrap the [types.Task], submit it to the pool, and wait for the result.
-// The [Submit] helper implements error handling correctly and is less error prone than using this wrapper and calling
-// [types.Pool.Submit] directly.
+// It is recommended not to use this wrapper directly, but rather use the [workpool.Submit] helper function.
+// The [workpool.Submit] helper will wrap the [types.Task], submit it to the pool, and wait for the result.
+// The [workpool.Submit] helper implements error handling correctly and is less error prone than using this wrapper and
+// calling [types.Pool.Submit] directly.
 func WrapTask[PoolResourceT any, ValueT any](
 	task types.Task[PoolResourceT, ValueT],
 ) (types.ValuelessTask[PoolResourceT], types.TaskResult[ValueT]) {
@@ -38,11 +38,12 @@ func WrapTask[PoolResourceT any, ValueT any](
 // The buffer size of the results channel is specified by the buffer parameter.
 // It is recommended avoid using a buffer size of 0, as this will block the worker until the result is received.
 //
-// It is recommended not to use this wrapper directly, but rather use the [SubmitMultiResultBuffered] helper function.
-// The [SubmitMultiResultBuffered] helper will wrap the [types.MultiResultTask], submit it to the pool, and call the
-// callback for each result as it is produced.
-// The [SubmitMultiResultBuffered] helper implements error handling correctly and is less error prone than using
-// this wrapper and calling [types.Pool.Submit] directly.
+// It is recommended not to use this wrapper directly, but rather use the [workpool.SubmitMultiResultBuffered] helper
+// function.
+// The [workpool.SubmitMultiResultBuffered] helper will wrap the [types.MultiResultTask], submit it to the pool, and
+// call the callback for each result as it is produced.
+// The [workpool.SubmitMultiResultBuffered] helper implements error handling correctly and is less error prone than
+// using this wrapper and calling [types.Pool.Submit] directly.
 func WrapMultiResultTaskBuffered[PoolResourceT any, ValueT any](
 	task types.MultiResultTask[PoolResourceT, ValueT],
 	buffer uint,
@@ -64,7 +65,7 @@ func WrapMultiResultTaskBuffered[PoolResourceT any, ValueT any](
 }
 
 // WrapMultiResultTask wraps a [types.MultiResultTask] with a buffer size of 1.
-// This is equivalent to calling [WrapMultiResultTaskBuffered] with a buffer size of 1.
+// This is equivalent to calling [workpool.WrapMultiResultTaskBuffered] with a buffer size of 1.
 func WrapMultiResultTask[PoolResourceT any, ValueT any](
 	task types.MultiResultTask[PoolResourceT, ValueT],
 ) (types.ValuelessTask[PoolResourceT], types.TaskResult[ValueT]) {
@@ -73,7 +74,7 @@ func WrapMultiResultTask[PoolResourceT any, ValueT any](
 
 // WrapTaskFunc wraps a [types.TaskFunc] so that it can be executed in a [types.Pool] and returns a [types.TaskResult]
 // for execution monitoring and error propagation.
-// It is not recommended to use this wrapper directly, but rather use the [SubmitFunc] helper function.
+// It is not recommended to use this wrapper directly, but rather use the [workpool.SubmitFunc] helper function.
 func WrapTaskFunc[PoolResourceT any](f types.TaskFunc[PoolResourceT]) (
 	types.ValuelessTask[PoolResourceT], types.TaskResult[struct{}],
 ) {

--- a/workpool/task/task.go
+++ b/workpool/task/task.go
@@ -18,9 +18,9 @@ import (
 // The [workpool.Submit] helper will wrap the [types.Task], submit it to the pool, and wait for the result.
 // The [workpool.Submit] helper implements error handling correctly and is less error prone than using this wrapper and
 // calling [types.Pool.Submit] directly.
-func WrapTask[PoolResourceT any, ValueT any](
-	task types.Task[PoolResourceT, ValueT],
-) (types.ValuelessTask[PoolResourceT], types.TaskResult[ValueT]) {
+func WrapTask[ResourceT any, ValueT any](
+	task types.Task[ResourceT, ValueT],
+) (types.ValuelessTask[ResourceT], types.TaskResult[ValueT]) {
 	res := make(chan ValueT, 1)
 	// taskResult.err and wrappedTask.err must point to the same error variable.
 	var err error
@@ -28,7 +28,7 @@ func WrapTask[PoolResourceT any, ValueT any](
 		results: res,
 		err:     &err,
 	}
-	wrappedTask := &taskWrapper[PoolResourceT, ValueT]{task, res, &err}
+	wrappedTask := &taskWrapper[ResourceT, ValueT]{task, res, &err}
 
 	return wrappedTask, taskResult
 }
@@ -44,10 +44,10 @@ func WrapTask[PoolResourceT any, ValueT any](
 // call the callback for each result as it is produced.
 // The [workpool.SubmitMultiResultBuffered] helper implements error handling correctly and is less error prone than
 // using this wrapper and calling [types.Pool.Submit] directly.
-func WrapMultiResultTaskBuffered[PoolResourceT any, ValueT any](
-	task types.MultiResultTask[PoolResourceT, ValueT],
+func WrapMultiResultTaskBuffered[ResourceT any, ValueT any](
+	task types.MultiResultTask[ResourceT, ValueT],
 	buffer uint,
-) (types.ValuelessTask[PoolResourceT], types.TaskResult[ValueT]) {
+) (types.ValuelessTask[ResourceT], types.TaskResult[ValueT]) {
 	res := make(chan ValueT, buffer)
 	handle := results.NewHandle(res)
 	var err error
@@ -55,7 +55,7 @@ func WrapMultiResultTaskBuffered[PoolResourceT any, ValueT any](
 		results: res,
 		err:     &err,
 	}
-	wrappedTask := multiResultTaskWrapper[PoolResourceT, ValueT]{
+	wrappedTask := multiResultTaskWrapper[ResourceT, ValueT]{
 		task:   task,
 		handle: handle,
 		err:    &err,
@@ -66,19 +66,19 @@ func WrapMultiResultTaskBuffered[PoolResourceT any, ValueT any](
 
 // WrapMultiResultTask wraps a [types.MultiResultTask] with a buffer size of 1.
 // This is equivalent to calling [workpool.WrapMultiResultTaskBuffered] with a buffer size of 1.
-func WrapMultiResultTask[PoolResourceT any, ValueT any](
-	task types.MultiResultTask[PoolResourceT, ValueT],
-) (types.ValuelessTask[PoolResourceT], types.TaskResult[ValueT]) {
+func WrapMultiResultTask[ResourceT any, ValueT any](
+	task types.MultiResultTask[ResourceT, ValueT],
+) (types.ValuelessTask[ResourceT], types.TaskResult[ValueT]) {
 	return WrapMultiResultTaskBuffered(task, 1)
 }
 
 // WrapTaskFunc wraps a [types.TaskFunc] so that it can be executed in a [types.Pool] and returns a [types.TaskResult]
 // for execution monitoring and error propagation.
 // It is not recommended to use this wrapper directly, but rather use the [workpool.SubmitFunc] helper function.
-func WrapTaskFunc[PoolResourceT any](f types.TaskFunc[PoolResourceT]) (
-	types.ValuelessTask[PoolResourceT], types.TaskResult[struct{}],
+func WrapTaskFunc[ResourceT any](f types.TaskFunc[ResourceT]) (
+	types.ValuelessTask[ResourceT], types.TaskResult[struct{}],
 ) {
-	return WrapTask[PoolResourceT, struct{}](taskFuncWrapper[PoolResourceT]{f})
+	return WrapTask[ResourceT, struct{}](taskFuncWrapper[ResourceT]{f})
 }
 
 // taskResult implements [types.TaskResult].
@@ -104,30 +104,30 @@ func (tr *taskResult[ValueT]) Drain() error {
 }
 
 // multiResultTaskWrapper is a wrapper for a [types.MultiResultTask] implementing [types.ValuelessTask].
-type multiResultTaskWrapper[PoolResourceT any, ValueT any] struct {
-	task   types.MultiResultTask[PoolResourceT, ValueT]
+type multiResultTaskWrapper[ResourceT any, ValueT any] struct {
+	task   types.MultiResultTask[ResourceT, ValueT]
 	handle types.Handle[ValueT]
 	err    *error
 }
 
 // Execute implements [types.MultiResultTask.Execute].
-func (t multiResultTaskWrapper[PoolResourceT, ValueT]) Execute(ctx context.Context, resource PoolResourceT) {
+func (t multiResultTaskWrapper[ResourceT, ValueT]) Execute(ctx context.Context, resource ResourceT) {
 	defer t.handle.Close()
 	// We must not overwrite the error pointer, but instead store the error at the address of the pointer.
 	*t.err = t.task.Execute(ctx, resource, t.handle)
 }
 
 // taskWrapper is a wrapper for a [types.Task] implementing [types.ValuelessTask].
-type taskWrapper[PoolResourceT any, ValueT any] struct {
-	task types.Task[PoolResourceT, ValueT]
+type taskWrapper[ResourceT any, ValueT any] struct {
+	task types.Task[ResourceT, ValueT]
 	r    chan<- ValueT
 	err  *error
 }
 
 // Execute implements [types.ValuelessTask.Execute].
-func (t taskWrapper[PoolResourceT, ValueT]) Execute(
+func (t taskWrapper[ResourceT, ValueT]) Execute(
 	ctx context.Context,
-	resource PoolResourceT,
+	resource ResourceT,
 ) {
 	defer close(t.r)
 	// taskWithHandleWrapper will close the handle for us when the task is done.
@@ -140,14 +140,14 @@ func (t taskWrapper[PoolResourceT, ValueT]) Execute(
 }
 
 // taskFunc is a function that implements [types.Task].
-type taskFuncWrapper[PoolResourceT any] struct {
-	f types.TaskFunc[PoolResourceT]
+type taskFuncWrapper[ResourceT any] struct {
+	f types.TaskFunc[ResourceT]
 }
 
 // Execute implements [types.Task.Execute].
-func (t taskFuncWrapper[PoolResourceT]) Execute(
+func (t taskFuncWrapper[ResourceT]) Execute(
 	ctx context.Context,
-	resource PoolResourceT,
+	resource ResourceT,
 ) (struct{}, error) {
 	return struct{}{}, t.f(ctx, resource)
 }

--- a/workpool/task/task_test.go
+++ b/workpool/task/task_test.go
@@ -1,4 +1,4 @@
-package workpool
+package task
 
 import (
 	"context"

--- a/workpool/util.go
+++ b/workpool/util.go
@@ -7,18 +7,19 @@ import (
 
 	"github.com/Izzette/go-safeconcurrency/api/safeconcurrencyerrors"
 	"github.com/Izzette/go-safeconcurrency/api/types"
+	"github.com/Izzette/go-safeconcurrency/workpool/task"
 )
 
 // Submit is a helper function to submit a [types.Task] to a [types.Pool] and wait for the result.
 func Submit[PoolResourceT any, ValueT any](
 	ctx context.Context,
 	pool types.Pool[PoolResourceT],
-	task types.Task[PoolResourceT, ValueT],
+	tsk types.Task[PoolResourceT, ValueT],
 ) (ValueT, error) {
 	var zero ValueT
 
 	// Wrap the task in a ValuelessTask to be able to submit it to the pool.
-	valuelessTask, taskResults := WrapTask[PoolResourceT, ValueT](task)
+	valuelessTask, taskResults := task.WrapTask[PoolResourceT, ValueT](tsk)
 
 	// Submit the task to the pool.
 	// If context is canceled before the task is published it will instead return an error.
@@ -62,16 +63,16 @@ func Submit[PoolResourceT any, ValueT any](
 //
 // # Other
 //
-// If you need more control, use [WrapMultiResultTaskBuffered] and call [types.Pool.Submit] directly.
+// If you need more control, use [task.WrapMultiResultTaskBuffered] and call [types.Pool.Submit] directly.
 func SubmitMultiResultBuffered[PoolResourceT any, ValueT any](
 	ctx context.Context,
 	pool types.Pool[PoolResourceT],
-	task types.MultiResultTask[PoolResourceT, ValueT],
+	tsk types.MultiResultTask[PoolResourceT, ValueT],
 	buffer uint,
 	callback types.TaskCallback[ValueT],
 ) error {
 	// Wrap the task in a ValuelessTask to be able to submit it to the pool.
-	valuelessTask, taskResults := WrapMultiResultTaskBuffered[PoolResourceT](task, buffer)
+	valuelessTask, taskResults := task.WrapMultiResultTaskBuffered[PoolResourceT](tsk, buffer)
 
 	// Only drain the results channel if the task was submitted successfully.
 	// We should always have already drained the results channel below, but this is a
@@ -161,7 +162,7 @@ func SubmitFunc[PoolResourceT any](
 	taskFunc types.TaskFunc[PoolResourceT],
 ) error {
 	// Wrap the task in a ValuelessTask to be able to submit it to the pool.
-	valuelessTask, taskResults := WrapTaskFunc[PoolResourceT](taskFunc)
+	valuelessTask, taskResults := task.WrapTaskFunc[PoolResourceT](taskFunc)
 
 	// Submit the task to the pool.
 	// If context is canceled before the task is published it will instead return an error.

--- a/workpool/util.go
+++ b/workpool/util.go
@@ -11,15 +11,15 @@ import (
 )
 
 // Submit is a helper function to submit a [types.Task] to a [types.Pool] and wait for the result.
-func Submit[PoolResourceT any, ValueT any](
+func Submit[ResourceT any, ValueT any](
 	ctx context.Context,
-	pool types.Pool[PoolResourceT],
-	tsk types.Task[PoolResourceT, ValueT],
+	pool types.Pool[ResourceT],
+	tsk types.Task[ResourceT, ValueT],
 ) (ValueT, error) {
 	var zero ValueT
 
 	// Wrap the task in a ValuelessTask to be able to submit it to the pool.
-	valuelessTask, taskResults := task.WrapTask[PoolResourceT, ValueT](tsk)
+	valuelessTask, taskResults := task.WrapTask[ResourceT, ValueT](tsk)
 
 	// Submit the task to the pool.
 	// If context is canceled before the task is published it will instead return an error.
@@ -64,15 +64,15 @@ func Submit[PoolResourceT any, ValueT any](
 // # Other
 //
 // If you need more control, use [task.WrapMultiResultTaskBuffered] and call [types.Pool.Submit] directly.
-func SubmitMultiResultBuffered[PoolResourceT any, ValueT any](
+func SubmitMultiResultBuffered[ResourceT any, ValueT any](
 	ctx context.Context,
-	pool types.Pool[PoolResourceT],
-	tsk types.MultiResultTask[PoolResourceT, ValueT],
+	pool types.Pool[ResourceT],
+	tsk types.MultiResultTask[ResourceT, ValueT],
 	buffer uint,
 	callback types.TaskCallback[ValueT],
 ) error {
 	// Wrap the task in a ValuelessTask to be able to submit it to the pool.
-	valuelessTask, taskResults := task.WrapMultiResultTaskBuffered[PoolResourceT](tsk, buffer)
+	valuelessTask, taskResults := task.WrapMultiResultTaskBuffered[ResourceT](tsk, buffer)
 
 	// Only drain the results channel if the task was submitted successfully.
 	// We should always have already drained the results channel below, but this is a
@@ -120,10 +120,10 @@ func SubmitMultiResultBuffered[PoolResourceT any, ValueT any](
 // It is equivalent to calling [SubmitMultiResultBuffered] with a buffer size of 1.
 // If you would like results buffering, use [SubmitMultiResultBuffered] instead.
 // See [SubmitMultiResultBuffered] for more details.
-func SubmitMultiResult[PoolResourceT any, ValueT any](
+func SubmitMultiResult[ResourceT any, ValueT any](
 	ctx context.Context,
-	pool types.Pool[PoolResourceT],
-	task types.MultiResultTask[PoolResourceT, ValueT],
+	pool types.Pool[ResourceT],
+	task types.MultiResultTask[ResourceT, ValueT],
 	callback types.TaskCallback[ValueT],
 ) error {
 	return SubmitMultiResultBuffered(ctx, pool, task, 1, callback)
@@ -138,10 +138,10 @@ func SubmitMultiResult[PoolResourceT any, ValueT any](
 // SubmitMultiResultCollectAll useful for testing, debugging, and demonstration purposes where the performance
 // difference is unimportant and the ability to consume the results as they are produced is not required.
 // You should most likely use [SubmitMultiResult] instead.
-func SubmitMultiResultCollectAll[PoolResourceT any, ValueT any](
+func SubmitMultiResultCollectAll[ResourceT any, ValueT any](
 	ctx context.Context,
-	pool types.Pool[PoolResourceT],
-	task types.MultiResultTask[PoolResourceT, ValueT],
+	pool types.Pool[ResourceT],
+	task types.MultiResultTask[ResourceT, ValueT],
 ) ([]ValueT, error) {
 	results := make([]ValueT, 0)
 	if err := SubmitMultiResult(ctx, pool, task, func(ctx context.Context, value ValueT) error {
@@ -156,13 +156,13 @@ func SubmitMultiResultCollectAll[PoolResourceT any, ValueT any](
 }
 
 // SubmitFunc is a helper function to submit a [types.TaskFunc] to a [types.Pool].
-func SubmitFunc[PoolResourceT any](
+func SubmitFunc[ResourceT any](
 	ctx context.Context,
-	pool types.Pool[PoolResourceT],
-	taskFunc types.TaskFunc[PoolResourceT],
+	pool types.Pool[ResourceT],
+	taskFunc types.TaskFunc[ResourceT],
 ) error {
 	// Wrap the task in a ValuelessTask to be able to submit it to the pool.
-	valuelessTask, taskResults := task.WrapTaskFunc[PoolResourceT](taskFunc)
+	valuelessTask, taskResults := task.WrapTaskFunc[ResourceT](taskFunc)
 
 	// Submit the task to the pool.
 	// If context is canceled before the task is published it will instead return an error.

--- a/workpool/util_test.go
+++ b/workpool/util_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/Izzette/go-safeconcurrency/api/types"
 )
 
+type mockTask struct {
+	val int
+	err error
+}
+
+func (t *mockTask) Execute(ctx context.Context, res interface{}) (int, error) {
+	return t.val, t.err
+}
+
 func TestSubmitSuccess(t *testing.T) {
 	ctx := context.Background()
 	p := NewPool[any](nil, 1)
@@ -146,6 +155,16 @@ func TestSubmitMultiResultTaskError(t *testing.T) {
 	if !errors.Is(err, expectedErr) {
 		t.Errorf("Expected error %v, got %v", expectedErr, err)
 	}
+}
+
+type mockMultiResultTask struct{ t *testing.T }
+
+func (t *mockMultiResultTask) Execute(ctx context.Context, res interface{}, h types.Handle[string]) error {
+	if err := h.Publish(ctx, "test"); err != nil {
+		t.t.Errorf("Failed to publish result: %v", err)
+	}
+
+	return nil
 }
 
 func TestSubmitMultiResultEarlyContextCanceled(t *testing.T) {


### PR DESCRIPTION
- fix: move task wrappers out of workpool and into workpool/task
- fix: rename PoolResourceT to ResourceT for brevity
