### PR TITLE
feat(eventloop): Add event loops

### DIFF
--- a/api/safeconcurrencyerrors/errors.go
+++ b/api/safeconcurrencyerrors/errors.go
@@ -5,3 +5,6 @@ package safeconcurrencyerrors
 //
 //nolint:errname
 const Stop = constantError("stop")
+
+// ErrEventLoopClosed is returned when the event loop is closed and no more snapshots will be available.
+const ErrEventLoopClosed = constantError("event loop closed")

--- a/api/types/eventloop.go
+++ b/api/types/eventloop.go
@@ -1,0 +1,80 @@
+package types
+
+import "context"
+
+// GenerationID is a monotonically increasing ID that is used to identify the state of the event loop at a given point
+// in time.
+type GenerationID uint64
+
+// EventLoop dispatches [Event] instances in a loop, processing them one at a time.
+//
+// # Synchronization
+//
+// [types.EventLoop.Send] does not wait for the event to be processed, and returns immediately upon enqueuing the
+// [Event].
+// The returned [GenerationID] will be the ID of the [StateSnapshot] that will be available after the [Event] is
+// processed.
+// If you want to wait for the event to be processed, you can use the
+// [github.com/Izzette/go-safeconcurrency/eventloop.WaitForGeneration] or
+// [github.com/Izzette/go-safeconcurrency/eventloop.SendAndWait] helper functions.
+//
+// See [github.com/Izzette/go-safeconcurrency/eventloop.NewBuffered] to create event loops and for more details
+// on how to use them.
+type EventLoop[StateT any] interface {
+	// Start initializes the event loop and prepares it for event subscription.
+	Start()
+
+	// Close closes the requests channel and waits for all events to complete.
+	// Any calls to Send after Close will panic.
+	// It is safe to call Close multiple times, or to call close before Start.
+	Close()
+
+	// Done returns a channel that is closed when the event loop is closed and all events have been processed.
+	Done() <-chan struct{}
+
+	// Send enqueues an event to the event loop for processing.
+	// If the context is canceled, the event will not be enqueued and an error will be returned.
+	// The returned GenerationID will be the ID of the StateSnapshot available after the event is processed.
+	Send(context.Context, Event[StateT]) (GenerationID, error)
+
+	// Snapshot returns a StateSnapshot with a copy of the current state of the event loop.
+	// Do not modify the state pointer returned by this method, as it will be shared with all other snapshots of the same
+	// GenerationID.
+	Snapshot() StateSnapshot[StateT]
+}
+
+// Event represents a unit of work that can be dispatched in an event loop.
+type Event[StateT any] interface {
+	// Dispatch is called when the event is processed in the loop.
+	//
+	//  - GenerationID: the ID of the state snapshot that will be available after the event is processed.
+	//  - *StateT: a pointer to a shallow copy of the state.  Updates to the state will be persisted after the event is
+	//    processed.
+	//
+	// The event loop will be blocked until the event is processed.
+	// If the state passed to the dispatch method is modified after the event is processed, the changes will not be
+	// persisted (for example, if the event dispatches a goroutine).
+	Dispatch(GenerationID, *StateT)
+}
+
+// StateSnapshot is an interface that represents a snapshot of the state at a given point in time.
+// It is returned by the [types.EventLoop.Snapshot] method.
+// Snapshots are used to provide a consistent view of the state from outside the event loop.
+type StateSnapshot[StateT any] interface {
+	// This returns the state at the time of the snapshot.
+	// Do not modify the state pointer returned by this method, as it will be shared with all other snapshots of the same
+	// GenerationID.
+	State() *StateT
+
+	// Generation returns the monotonically increasing generation ID of the state snapshot.
+	// This ID is incremented each time an event is processed in the event loop.
+	Generation() GenerationID
+
+	// Expiration returns a channel which is closed when the state snapshot is no longer valid.
+	// This will occur each time an event finishes processing in the event loop.
+	// If the event loop is closed, this channel will never be closed as the snapshot is still valid.
+	// If you would like to also check if the event loop is closed, you can use a select statement to wait for both
+	// EventLoop.Done() and StateSnapshot.Expiration() channels.
+	// The helper function eventloop.WaitForGeneration and eventloop.SendAndWait will do this for you.
+	Expiration() <-chan struct{}
+}

--- a/eventloop/benchmark_test.go
+++ b/eventloop/benchmark_test.go
@@ -1,0 +1,53 @@
+package eventloop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Izzette/go-safeconcurrency/api/types"
+)
+
+// BenchmarkEventLoopThroughput measures the throughput of the [types.EventLoop].
+// It sends a large number of simple [types.Event] instances, checking that the [types.StateSnapshot] is updated
+// correctly, and measures the time taken.
+// It's performance is heavily tied to the performance of [workpool.Submit].
+func BenchmarkEventLoopThroughput(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	el := NewBuffered[int](new(int), 16)
+	defer el.Close()
+	defer cancel()
+	el.Start()
+
+	b.ResetTimer()
+	var gen types.GenerationID
+	for i := 0; i < b.N; i++ {
+		var err error
+		gen, err = el.Send(ctx, &benchEvent{})
+		if err != nil {
+			b.Fatalf("failed to send event: %v", err)
+		}
+	}
+
+	// Wait for all events to process
+	snap, err := WaitForGeneration(ctx, el, gen)
+	if err != nil {
+		b.Fatalf("failed to wait for event: %v", err)
+	}
+
+	// Stop timer to avoid including the teardown time in the benchmark
+	b.StopTimer()
+
+	if *snap.State() != b.N {
+		b.Errorf("expected state %d, got %d", b.N, *snap.State())
+	}
+}
+
+// benchEvent is an implementation of [types.Event] that increments a counter.
+type benchEvent struct{}
+
+// Dispatch implements [types.Event.Dispatch].
+func (e *benchEvent) Dispatch(_ types.GenerationID, s *int) {
+	*s++
+}

--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -1,0 +1,273 @@
+package eventloop
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/Izzette/go-safeconcurrency/api/types"
+	"github.com/Izzette/go-safeconcurrency/workpool"
+	"github.com/Izzette/go-safeconcurrency/workpool/task"
+)
+
+// NewBuffered creates (but does not start) a basic implementation of [types.EventLoop].
+//
+// # Parameters
+//
+//   - state: A pointer to the state to be passed to the event loop (type *StateT).
+//   - buffer: The size of the event queue. This is the number of events that can be queued before blocking on
+//     publication.
+//
+// # State
+//
+// The event loop is designed to be used with a shared state, which is passed to each event when it is dispatched.
+// At each event execution, the event loop will make a shallow copy of the state and pass it to the event.
+// The event can then modify the state, and the changes will be persisted to the snapshot after the event is finished,
+// and will be visible to future events.
+// Keep in mind that the state is only copied at the top-level (via pointer dereference), so if the state contains any
+// reference types, those will not be copied and will be shared between the event loop and any snapshots taken.
+// Reference types include:
+//
+//   - Maps
+//   - Slices
+//   - Interfaces
+//   - Pointers
+//   - Channels
+//   - Functions
+//
+// It is recommended to use exclusively value types for the state (such as structs without reference fields), or to use
+// a copy-on-write strategy for reference types.
+// This will ensure that the snapshots taken by the event loop are consistent and do not interfere with the state of the
+// event loop.
+//
+// Example of a value type state:
+//
+//	// State is used as the state for the event loop, it has no reference types.
+//	type State struct {
+//		// Count is a value type, so we don't need to worry about copying it.
+//		Count int
+//
+//		// Other bs a struct (not a pointer to a struct) with no reference types.
+//		Other struct{
+//			// Ready is a value type, so we don't need to worry about copying it.
+//			Ready bool
+//			// Value is immutable, so we don't need to worry about copying it either.
+//			Value string
+//		}
+//	}
+//
+// Example of a state with reference types and copy-on-write strategy:
+//
+//	// State is used as the state for the event loop, it has reference types but exposes copy-on-write methods.
+//	type State struct {
+//		// Count is a value type, so we don't need to worry about copying it.
+//		Count int
+//
+//		// other is a map of string to string.
+//		// This is a reference type, so we need to use a copy-on-write strategy to avoid modifying the original.
+//		// This map is copied on write, so that each event can modify it without affecting the original.
+//		// As strings are immutable, we don't need to worry about modifying the original string.
+//		// If we were to use a map of pointers, we would need to copy the pointers as well.
+//		other map[string]string
+//	}
+//
+//	// GetOther returns the value of the given key in the other map.
+//	// This prevents exposing the original map, preventing unintended modifications.
+//	func (s *State) GetOther(key string) string {
+//		return s.other[key]
+//	}
+//
+//	// SetOther sets the value of the given key in the other map.
+//	// Allows modifying the map without updating the original present in snapshots.
+//	func (s *State) SetOther(key string, value string) {
+//		// Copy the map to avoid modifying the original
+//		other := make(map[string]string)
+//		for k, v := range s.other {
+//			other[k] = v
+//		}
+//		// Update the map
+//		other[key] = value
+//		// Replace the map with the updated one
+//		s.other = other
+//	}
+//
+// # Generation
+//
+// Each state snapshot will be assigned a unique monotonically increasing generation ID, starting at 0.
+// This generation ID is incremented each time after an event is processed in the event loop, and the new snapshot is
+// available.
+// When submitting an event, the [types.GenerationID] that will be assigned to the state snapshot after the event is
+// processed is returned.
+//
+// # Snapshot
+//
+// The [types.EventLoop.Snapshot] method will return a [types.StateSnapshot], allowing access to:
+//
+//   - A copy of the state at the time of the snapshot.
+//   - The generation ID of the snapshot.
+//   - A channel that is closed when the state is no longer valid (as soon as the next event is processed).
+//
+// Do not modify the state pointer returned by this method, as it will be shared with all other snapshots of the same
+// generation ID.
+//
+// # Starting and stopping the Event Loop
+//
+// The [types.EventLoop.Start] method must be called to start the event loop.
+// It may be called after the [types.EventLoop.Close] or [types.EventLoop.Send] methods have been called.
+// It is recommended to defer the call to [types.EventLoop.Close] immediately after creating the event loop to avoid
+// leaking the goroutines used to process events and any references they may prevent from being garbage collected.
+func NewBuffered[StateT any](state *StateT, buffer uint) types.EventLoop[StateT] {
+	snapshotPtr := &atomic.Pointer[snapshot[StateT]]{}
+	snapshotPtr.Store(&snapshot[StateT]{
+		gen:        0,
+		state:      copyPtr(state), // Make a shallow copy of the state.
+		expiration: make(chan struct{}),
+	})
+	submissionPool := workpool.New[*types.GenerationID](new(types.GenerationID), 1)
+	eventPool := workpool.NewBuffered[*atomic.Pointer[snapshot[StateT]]](snapshotPtr, 1, buffer)
+
+	return &eventLoop[StateT]{
+		done:      make(chan struct{}),
+		closeOnce: &sync.Once{},
+
+		submissionPool: submissionPool,
+		eventPool:      eventPool,
+
+		snapshotPtr: snapshotPtr,
+	}
+}
+
+// New creates (but does not start) a basic implementation of [types.EventLoop].
+// It is equivalent to calling [NewBuffered] with a buffer size of 0.
+// If you would like to use a buffer size, use [NewBuffered] instead.
+func New[StateT any](state *StateT) types.EventLoop[StateT] {
+	return NewBuffered(state, 0)
+}
+
+// eventLoop is an implementation of [types.EventLoop].
+type eventLoop[StateT any] struct {
+	done      chan struct{}
+	closeOnce *sync.Once
+
+	// expectedGenID submits the event to the eventPool and increments the expected generation ID.
+	// It is used to ensure that the event is processed in the order it was submitted.
+	// It must have no buffering to ensure that context deadlines of submitted tasks are respected.
+	submissionPool types.WorkerPool[*types.GenerationID]
+	eventPool      types.WorkerPool[*atomic.Pointer[snapshot[StateT]]]
+
+	snapshotPtr *atomic.Pointer[snapshot[StateT]]
+}
+
+// Start implements [types.EventLoop.Start].
+func (l *eventLoop[StateT]) Start() {
+	l.eventPool.Start()
+	l.submissionPool.Start()
+}
+
+// Close implements [types.EventLoop.Close].
+func (l *eventLoop[StateT]) Close() {
+	// Close the pools and wait for all tasks to complete.
+	l.submissionPool.Close()
+	l.eventPool.Close()
+	l.closeOnce.Do(l.closeDone)
+}
+
+// Done implements [types.EventLoop.Done].
+func (l *eventLoop[StateT]) Done() <-chan struct{} {
+	return l.done
+}
+
+// Send implements [types.EventLoop.Send].
+func (l *eventLoop[StateT]) Send(ctx context.Context, event types.Event[StateT]) (types.GenerationID, error) {
+	// select is not deterministic, and may still send tasks even if the context has been canceled.
+	if err := context.Cause(ctx); err != nil {
+		//nolint:wrapcheck
+		return 0, err
+	}
+
+	// The eventTask will be submitted to the l.pool by the submitEventTask.
+	eventTask := &eventWrapper[StateT]{
+		event: event,
+	}
+	// The submitEventTask will be submitted to the l.expectedGenPool, which will provide the generation ID
+	// without explicit locking while respecting the context deadline.
+	submitTask := &submitEventTask[StateT]{
+		task: eventTask,
+		pool: l.eventPool,
+	}
+
+	// In order to provide the guarantee that either the event was sent or an error is returned, we need to ensure
+	// that the task is dispatched so long as it is submitted to the pool, and wait for the result.
+	// As the expectedGenPool has no buffering, we can be sure that the task is being executed and will return if the
+	// context is cancelled.
+	// As a result the workpool.Submit helpers are not suitable for this use case, and we must wrap the task manually.
+	wrappedSubmitTask, results := task.Wrap[*types.GenerationID, types.GenerationID](ctx, submitTask)
+	select {
+	case <-ctx.Done():
+		//nolint:wrapcheck
+		return 0, context.Cause(ctx)
+	case l.submissionPool.Requests() <- wrappedSubmitTask:
+		// The task was successfully sent to the expectedGenPool.
+		expectedGen := <-results.Results()
+		err := results.Drain()
+
+		//nolint:wrapcheck
+		return expectedGen, err
+	}
+}
+
+type submitEventTask[StateT any] struct {
+	task types.ValuelessTask[*atomic.Pointer[snapshot[StateT]]]
+	pool types.WorkerPool[*atomic.Pointer[snapshot[StateT]]]
+}
+
+// Execute implements [types.Task.Execute].
+func (t *submitEventTask[StateT]) Execute(
+	ctx context.Context,
+	expectedGenPtr *types.GenerationID,
+) (types.GenerationID, error) {
+	select {
+	case <-ctx.Done():
+		//nolint:wrapcheck
+		return 0, context.Cause(ctx)
+	case t.pool.Requests() <- t.task:
+		// The task was successfully sent to the pool.
+		// Let's increment the expected generation ID.
+		*expectedGenPtr++
+
+		return *expectedGenPtr, nil
+	}
+}
+
+// Snapshot implements [types.EventLoop.Snapshot].
+func (l *eventLoop[StateT]) Snapshot() types.StateSnapshot[StateT] {
+	return l.snapshotPtr.Load()
+}
+
+// closeDone closes the done channel.
+// it does not synchronize with [eventLoop.closeOnce].
+func (l *eventLoop[StateT]) closeDone() {
+	close(l.done)
+}
+
+// eventWrapper is a wrapper for a [types.Event] implementing [types.ValuelessTask].
+type eventWrapper[StateT any] struct {
+	event types.Event[StateT]
+}
+
+// Execute implements [types.ValuelessTask.Execute].
+func (e *eventWrapper[StateT]) Execute(resource *atomic.Pointer[snapshot[StateT]]) {
+	originalSnap := resource.Load()
+	// Close the previous snapshot expiration channel signalling that a new state is available.
+	defer originalSnap.expire()
+
+	// Make a copy of the original snapshot and a shallow copy of the state.
+	snap := originalSnap.Copy()
+	snap.gen += 1
+
+	// Call the event's Dispatch method with the resource.
+	e.event.Dispatch(snap.gen, snap.state)
+
+	// Create a new stateGeneration with the new state and increment the generation.
+	resource.Store(snap)
+}

--- a/eventloop/eventloop_test.go
+++ b/eventloop/eventloop_test.go
@@ -1,0 +1,269 @@
+package eventloop
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Izzette/go-safeconcurrency/api/safeconcurrencyerrors"
+	"github.com/Izzette/go-safeconcurrency/api/types"
+)
+
+type testEvent struct {
+	fn func(gen types.GenerationID, s *testState)
+}
+
+type testState struct {
+	counter int
+}
+
+func (e *testEvent) Dispatch(gen types.GenerationID, s *testState) {
+	if e.fn == nil {
+		return
+	}
+
+	e.fn(gen, s)
+}
+
+func TestNewEventLoop(t *testing.T) {
+	el := New[any](nil)
+	defer el.Close()
+
+	if el == nil {
+		t.Fatal("expected non-nil EventLoop")
+	}
+}
+
+func TestEventLoopBasicOperation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &testState{counter: 0}
+	el := NewBuffered[testState](initialState, 10)
+	defer el.Close()
+	el.Start()
+
+	// Send increment events
+	for i := 0; i < 5; i++ {
+		if gen, err := el.Send(ctx, &testEvent{
+			fn: func(_ types.GenerationID, s *testState) {
+				s.counter++
+			},
+		}); err != nil {
+			t.Fatalf("failed to send event: %v", err)
+		} else if gen != types.GenerationID(i+1) {
+			t.Errorf("expected generation %d, got %d", i+1, gen)
+		}
+	}
+	// Wait for events to process
+	snap, err := WaitForGeneration(ctx, el, 5)
+	if err != nil {
+		t.Fatalf("failed to wait for event: %v", err)
+	}
+	if snap.Generation() != 5 {
+		t.Fatalf("expected generation 5, got %d", snap.Generation())
+	}
+	if snap.State().counter != 5 {
+		t.Fatalf("expected counter to be 5, got %d", snap.State().counter)
+	}
+}
+
+func TestEventLoopSnapshotGeneration(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &testState{counter: 0}
+	el := NewBuffered[testState](initialState, 0)
+	defer el.Close()
+	el.Start()
+
+	// Get initial snapshot
+	snap0 := el.Snapshot()
+	if snap0.Generation() != 0 {
+		t.Fatalf("expected initial counter to be 0, got %d", snap0.Generation())
+	}
+
+	// Send first event
+	if gen, err := el.Send(
+		ctx, &testEvent{fn: func(gen types.GenerationID, s *testState) {
+			if gen != 1 {
+				t.Errorf("expected generation 1, got %d", gen)
+			}
+			s.counter++
+		}},
+	); err != nil {
+		t.Fatalf("failed to send event: %v", err)
+	} else if gen != 1 {
+		t.Errorf("expected generation 1, got %d", gen)
+	}
+
+	snap1, err := WaitForGeneration(ctx, el, 1)
+	if err != nil {
+		t.Errorf("failed to wait for event: %v", err)
+	} else if snap1.Generation() != 1 {
+		t.Errorf("expected counter to be 1, got %d", snap1.Generation())
+	}
+}
+
+func TestEventLoopContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &testState{counter: 0}
+	el := NewBuffered[testState](initialState, 0)
+	defer el.Close()
+	el.Start()
+
+	// Cancel context before sending
+	cancel()
+
+	_, err := el.Send(ctx, &testEvent{})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got %v", err)
+	}
+}
+
+func TestWaitForCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &testState{counter: 0}
+	el := New[testState](initialState)
+	defer el.Close()
+	el.Start()
+
+	// Cancel context before waiting
+	cancel()
+
+	snap, err := WaitForGeneration(ctx, el, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got %v", err)
+	}
+	if snap != nil {
+		t.Errorf("expected nil snapshot, got %v", snap)
+	}
+}
+
+func TestWaitForLoopClosed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &testState{counter: 0}
+	el := NewBuffered[testState](initialState, 0)
+	defer el.Close()
+	el.Start()
+
+	// Close the event loop
+	el.Close()
+
+	snap, err := WaitForGeneration(ctx, el, 1)
+	if !errors.Is(err, safeconcurrencyerrors.ErrEventLoopClosed) {
+		t.Errorf("expected ErrEventLoopClosed error, got %v", err)
+	}
+	if snap != nil {
+		t.Errorf("expected nil snapshot, got %v", snap)
+	}
+}
+
+func TestSendAndWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &testState{counter: 0}
+	el := NewBuffered[testState](initialState, 0)
+	defer el.Close()
+	el.Start()
+
+	// Send an event and wait for it
+	snap, err := SendAndWait[testState](ctx, el, &testEvent{
+		fn: func(gen types.GenerationID, s *testState) {
+			if gen != 1 {
+				t.Errorf("expected generation 1, got %d", gen)
+			}
+			s.counter++
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to send and wait for event: %v", err)
+	}
+	if snap.State().counter != 1 {
+		t.Errorf("expected counter to be 1, got %d", snap.State().counter)
+	}
+	if snap.Generation() != 1 {
+		t.Errorf("expected generation 1, got %d", snap.Generation())
+	}
+}
+
+func TestEventLoopClosed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &testState{}
+	el := NewBuffered[testState](initialState, 1)
+	defer el.Close()
+	el.Start()
+
+	// Close the loop after sending
+	el.Close()
+
+	snap, err := WaitForGeneration(ctx, el, 3)
+	if !errors.Is(err, safeconcurrencyerrors.ErrEventLoopClosed) {
+		t.Errorf("expected ErrEventLoopClosed error, got %v", err)
+	}
+	if snap != nil {
+		t.Errorf("expected nil snapshot, got %v", snap)
+	}
+	if el.Snapshot().Generation() != 0 {
+		t.Errorf("expected generation 0, got %d", el.Snapshot().Generation())
+	}
+}
+
+func TestSendAndWaitSendCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &testState{}
+	el := New[testState](initialState)
+	defer el.Close()
+	el.Start()
+
+	// Cancel the context before sending
+	cancel()
+	_, err := SendAndWait[testState](ctx, el, &testEvent{})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got %v", err)
+	}
+	// Flush the event loop
+	el.Close()
+	if el.Snapshot().Generation() != 0 {
+		t.Errorf("expected generation 0, got %d", el.Snapshot().Generation())
+	}
+}
+
+func TestSendAndWaitWaitCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &testState{}
+	el := New[testState](initialState)
+	defer el.Close()
+	el.Start()
+
+	// Send an event which will cancel the context and wait
+	waitCtx, waitCancel := context.WithCancel(context.Background())
+	defer waitCancel()
+
+	_, err := SendAndWait[testState](ctx, el, &testEvent{fn: func(gen types.GenerationID, s *testState) {
+		cancel()
+		<-waitCtx.Done()
+	}})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got %v", err)
+	}
+	waitCancel()
+	// Flush the event loop
+	el.Close()
+	if el.Snapshot().Generation() != 1 {
+		t.Errorf("expected generation 1, got %d", el.Snapshot().Generation())
+	}
+}

--- a/eventloop/snapshot.go
+++ b/eventloop/snapshot.go
@@ -1,0 +1,45 @@
+package eventloop
+
+import "github.com/Izzette/go-safeconcurrency/api/types"
+
+// snapshot is an implementation of [types.StateSnapshot].
+type snapshot[StateT any] struct {
+	gen        types.GenerationID
+	state      *StateT
+	expiration chan struct{}
+}
+
+// Copy creates a copy of the snapshot.
+// A shallow copy of the state is made to allow modifications.
+// A new expiration channel is created, but the old one is not closed.
+func (s *snapshot[StateT]) Copy() *snapshot[StateT] {
+	// Make a shallow copy of the snapshot.
+	cpy := copyPtr(s)
+	// Make a shallow copy of the state.
+	cpy.state = copyPtr(s.state)
+	// Make a new expiration channel.
+	cpy.expiration = make(chan struct{})
+
+	// Return the copy.
+	return cpy
+}
+
+// State implements [types.StateSnapshot.State].
+func (s *snapshot[StateT]) State() *StateT {
+	return s.state
+}
+
+// Generation implements [types.StateSnapshot.Generation].
+func (s *snapshot[StateT]) Generation() types.GenerationID {
+	return s.gen
+}
+
+// Expiration implements [types.StateSnapshot.Expiration].
+func (s *snapshot[StateT]) Expiration() <-chan struct{} {
+	return s.expiration
+}
+
+// expire closes the expiration channel.
+func (s *snapshot[StateT]) expire() {
+	close(s.expiration)
+}

--- a/eventloop/snapshot_test.go
+++ b/eventloop/snapshot_test.go
@@ -1,0 +1,1 @@
+package eventloop

--- a/eventloop/util.go
+++ b/eventloop/util.go
@@ -1,0 +1,83 @@
+package eventloop
+
+import (
+	"context"
+
+	"github.com/Izzette/go-safeconcurrency/api/safeconcurrencyerrors"
+	"github.com/Izzette/go-safeconcurrency/api/types"
+)
+
+// WaitForGeneration waits for the [types.EventLoop] to process all [types.Events] up to (and including) the specified
+// [types.GenerationID].
+// It returns a [types.StateSnapshot] at or later than the [types.GenerationID].
+// If the [context.Context] was cancelled before the [types.EventLoop] reaches that [types.GenerationID], an error is
+// returned instead.
+// If the [types.EventLoop] is closed before the [types.GenerationID] is reached, an error is returned instead.
+func WaitForGeneration[StateT any](
+	ctx context.Context,
+	eventLoop types.EventLoop[StateT],
+	gen types.GenerationID,
+) (types.StateSnapshot[StateT], error) {
+	for {
+		snapshot := eventLoop.Snapshot()
+		if snapshot.Generation() >= gen {
+			// The snapshot is later than the requested generation, so we can return it.
+			return snapshot, nil
+		}
+
+		// Wait for the expiration channel to be closed.
+		select {
+		case <-ctx.Done():
+			//nolint:wrapcheck
+			return nil, context.Cause(ctx)
+		case <-eventLoop.Done():
+			// The event loop is closed, but we may have not seen the last snapshot yet because the select is not
+			// guaranteed to select on the first case that is ready if multiple cases are ready when it is woken up.
+			snapshot = eventLoop.Snapshot()
+			if snapshot.Generation() >= gen {
+				// The snapshot is later than the requested generation, so we can return it.
+				return snapshot, nil
+			}
+			// The event loop is closed before the requested generation is reached.
+			return nil, safeconcurrencyerrors.ErrEventLoopClosed
+		case <-snapshot.Expiration():
+		}
+	}
+}
+
+// SendAndWait is a convenience function that sends an event to the [types.EventLoop] and waits for it to be processed.
+// It is equivalent to calling [types.EventLoop.Send] and then [WaitForGeneration] with the returned generation ID.
+func SendAndWait[StateT any](
+	ctx context.Context,
+	eventLoop types.EventLoop[StateT],
+	event types.Event[StateT],
+) (types.StateSnapshot[StateT], error) {
+	gen, err := eventLoop.Send(ctx, event)
+	if err != nil {
+		//nolint:wrapcheck
+		return nil, err
+	}
+
+	// Wait for the event to be processed.
+	snap, err := WaitForGeneration(ctx, eventLoop, gen)
+	if err != nil {
+		return nil, err
+	}
+
+	return snap, nil
+}
+
+// copyPtr creates a shallow copy of value at the pointer p and returns a pointer to the copy.
+func copyPtr[T any](ptr *T) *T {
+	// If the pointer is nil, return nil.
+	if ptr == nil {
+		return nil
+	}
+
+	// Allocate a new pointer to the type T and copy the value from the original pointer.
+	cpy := new(T)
+	*cpy = *ptr
+
+	// Return the copy.
+	return cpy
+}

--- a/eventloop/util_test.go
+++ b/eventloop/util_test.go
@@ -1,0 +1,1 @@
+package eventloop

--- a/eventloop/watch.go
+++ b/eventloop/watch.go
@@ -1,0 +1,87 @@
+package eventloop
+
+import (
+	"context"
+
+	"github.com/Izzette/go-safeconcurrency/api/types"
+)
+
+// WatchStateFunc is a function that is called each time a new [types.StateSnapshot] is available.
+// If the function returns false, the watch will be cancelled.
+type WatchStateFunc[StateT any] func(context.Context, types.StateSnapshot[StateT]) bool
+
+// WatchState is a convenience function that watches the [types.StateSnapshot] instances of the [types.EventLoop] and
+// runs the provided function each time a new snapshot is available.
+//
+//   - ctx: the [context.Context] to use for the watch.
+//   - eventLoop: the [types.EventLoop] to watch for snapshots.
+//   - watcher: the [WatchStateFunc] to call each time a new snapshot is available.
+//
+// It will only run one invocation of the watcher at a time.
+// It returns a channel that is closed when the watch is cancelled.
+//
+// # Snapshots
+//
+// It is not guaranteed to see every [types.StateSnapshot], but the watcher will be run with the latest
+// [types.StateSnapshot] available since the previous snapshot expiration was observed.
+// If you have a high frequency of events or a slow watcher, you may miss some snapshots between invocations of the
+// watcher.
+// The watcher will never be called with the same snapshot twice.
+//
+// # Cancellation
+//
+// If the context is cancelled, the watch will be cancelled as well.
+// If the function returns false on any invocation, the watch will be cancelled.
+// In the case that the [types.EventLoop] is closed, the watch is guaranteed to be called with the last
+// [types.StateSnapshot] before cancelling the watch.
+// Whenever the watch to snapshots is cancelled, the context passed to the watcher will be cancelled, and the returned
+// channel will be closed.
+func WatchState[StateT any](
+	ctx context.Context,
+	eventLoop types.EventLoop[StateT],
+	watcher WatchStateFunc[StateT],
+) <-chan struct{} {
+	done := make(chan struct{})
+	go watchLoop(ctx, eventLoop, watcher, done)
+
+	return done
+}
+
+// watchLoop will call the watch function each time an event is executed in the event loop.
+func watchLoop[StateT any](
+	ctx context.Context,
+	eventLoop types.EventLoop[StateT],
+	watch WatchStateFunc[StateT],
+	done chan<- struct{},
+) {
+	defer close(done)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	snap := eventLoop.Snapshot()
+	for {
+		// Call the watch with the new snapshot.
+		if cont := watch(ctx, snap); !cont {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-eventLoop.Done():
+			// The event loop is closed, but we may have not seen the last snapshot yet because
+			// select is not guaranteed to select on the first case that is ready if multiple cases
+			// are ready when it is woken up.
+			previousGen := snap.Generation()
+			snap = eventLoop.Snapshot()
+			if snap.Generation() == previousGen {
+				// The event loop is closed and we have already seen the last snapshot.
+				return
+			}
+		case <-snap.Expiration():
+			// The snapshot is no longer valid, so we need to get a new one.
+			snap = eventLoop.Snapshot()
+		}
+	}
+}

--- a/eventloop/watch_test.go
+++ b/eventloop/watch_test.go
@@ -1,0 +1,114 @@
+package eventloop
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/Izzette/go-safeconcurrency/api/types"
+)
+
+func TestWatchState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a new event loop.
+	el := New[testState](&testState{})
+	defer el.Close()
+
+	// Start the event loop.
+	el.Start()
+
+	closeStartedOnce := &sync.Once{}
+	started := make(chan struct{})
+	done := WatchState(ctx, el, func(ctx context.Context, snap types.StateSnapshot[testState]) bool {
+		// Notify that the watcher has started.
+		closeStartedOnce.Do(func() {
+			close(started)
+		})
+
+		if snap.Generation() > 0 {
+			// Break on the second snapshot.
+			return false
+		}
+
+		return true
+	})
+
+	select {
+	case <-done:
+		t.Errorf("expected done channel to not be closed yet")
+	default: // do nothing
+	}
+
+	// Wait for the watcher to start before sending an event.
+	<-started
+
+	// Send an event to the event loop.
+	_, err := el.Send(ctx, &testEvent{})
+	if err != nil {
+		t.Fatalf("failed to send event: %v", err)
+	}
+
+	// The watch should be ended soon
+	_, ok := <-done
+	if ok {
+		t.Errorf("expected done channel to be closed, but found unexpected value in it")
+	}
+}
+
+func TestWatchStateCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a new event loop.
+	el := New[testState](&testState{})
+	defer el.Close()
+
+	// Start the event loop.
+	el.Start()
+
+	done := WatchState(ctx, el, func(ctx context.Context, snap types.StateSnapshot[testState]) bool {
+		if snap.Generation() > 0 {
+			// Break on the second snapshot.
+			return false
+		}
+
+		return true
+	})
+
+	cancel()
+
+	_, ok := <-done
+	if ok {
+		t.Errorf("expected done channel to be closed, but found unexpected value in it")
+	}
+}
+
+func TestWatchStateEventLoopClosed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a new event loop.
+	el := New[testState](&testState{})
+	defer el.Close()
+
+	// Start the event loop.
+	el.Start()
+
+	done := WatchState(ctx, el, func(ctx context.Context, snap types.StateSnapshot[testState]) bool {
+		if snap.Generation() > 0 {
+			// Break on the second snapshot.
+			return false
+		}
+
+		return true
+	})
+
+	el.Close()
+
+	_, ok := <-done
+	if ok {
+		t.Errorf("expected done channel to be closed, but found unexpected value in it")
+	}
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -97,6 +97,37 @@ Run with:
 go test -v -run Example_sharedPool
 ```
 
+#### Event Loop with State Snapshots
+
+**Files**: `eventloop_test.go`
+
+Demonstrates using the event loop to maintain consistent state snapshots.
+
+_Here's an abridged version of the example_:
+```go
+el := eventloop.New[AppState](ctx, &AppState{})
+defer el.Close()
+el.Start()
+
+snap, err := SendAndWait[AppState](ctx, el, &RequestEvent{})
+if err != nil {
+    panic(err)
+}
+fmt.Printf("Current requests: %d\n", snap.State().Requests)
+```
+
+Run with:
+```bash
+go test -v -run Example_eventLoop
+```
+#### Advanced Event Loop with Complex State Management
+
+**Files**: `ecommerceeventloop_test.go`
+
+Demonstrates a more complex event loop managing an e-commerce application state.
+This example shows how to handle multiple event types and maintain a consistent state.
+Some of the implementation has been moved to the [`ecommerce`](./ecommerce) package.
+
 ### Running Examples and Expected Outputs
 
 If you're not familiar with Go's runnable examples, they are a way to include

--- a/examples/ecommerce/events/cart.go
+++ b/examples/ecommerce/events/cart.go
@@ -1,0 +1,37 @@
+package events
+
+import (
+	"errors"
+
+	"github.com/Izzette/go-safeconcurrency/api/types"
+	"github.com/Izzette/go-safeconcurrency/examples/ecommerce/state"
+)
+
+// ErrCartEmpty is the error returned when the cart is empty
+var ErrCartEmpty = errors.New("cart is empty")
+
+// AddToCartEvent adds items to user's cart
+type AddToCartEvent struct {
+	// ProductID is the ID of the product to add
+	ProductID string
+
+	// Quantity is the number of items to add
+	Quantity int
+}
+
+// Dispatch implements [types.Event.Dispatch].
+func (e *AddToCartEvent) Dispatch(_ types.GenerationID, s *state.UserState) {
+	s.UpdateCart(e.ProductID, e.Quantity)
+}
+
+// RemoveFromCartEvent removes items from cart
+type RemoveFromCartEvent struct {
+	// ProductID is the ID of the product to remove
+	ProductID string
+}
+
+// Dispatch implements [types.Event.Dispatch].
+func (e *RemoveFromCartEvent) Dispatch(_ types.GenerationID, s *state.UserState) {
+	// Remove the product from the cart
+	s.UpdateCart(e.ProductID, 0)
+}

--- a/examples/ecommerce/events/order.go
+++ b/examples/ecommerce/events/order.go
@@ -1,0 +1,58 @@
+package events
+
+import (
+	"fmt"
+
+	"github.com/Izzette/go-safeconcurrency/api/types"
+	"github.com/Izzette/go-safeconcurrency/examples/ecommerce/state"
+)
+
+// CheckoutEvent converts cart to order
+type CheckoutEvent struct {
+	// OrderID is the ID of the order after creation
+	OrderID string
+
+	// Err is the error returned from the event
+	Err error
+}
+
+// Dispatch implements [types.Event.Dispatch].
+func (e *CheckoutEvent) Dispatch(_ types.GenerationID, s *state.UserState) {
+	cart := s.GetCart()
+	if len(cart) == 0 {
+		e.Err = ErrCartEmpty
+		return
+	}
+
+	order := &state.Order{
+		ID:     s.NextOrderID(),
+		Items:  make(map[string]int),
+		Status: "created",
+	}
+	for pid, qty := range s.GetCart() {
+		order.Items[pid] = qty
+	}
+	e.OrderID = order.ID
+	s.UpdateOrder(e.OrderID, order)
+	s.ClearCart()
+}
+
+// UpdateOrderStatusEvent changes order status
+type UpdateOrderStatusEvent struct {
+	// OrderID is the ID of the order to update
+	OrderID string
+
+	// Status is the new status for the order
+	Status string
+}
+
+// Dispatch implements [types.Event.Dispatch].
+func (e *UpdateOrderStatusEvent) Dispatch(_ types.GenerationID, s *state.UserState) {
+	order := s.GetOrder(e.OrderID)
+	if order == nil {
+		fmt.Printf("ERROR: order %s not found\n", e.OrderID)
+		return
+	}
+	order.Status = e.Status
+	s.UpdateOrder(e.OrderID, order)
+}

--- a/examples/ecommerce/events/stock.go
+++ b/examples/ecommerce/events/stock.go
@@ -1,0 +1,66 @@
+package events
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Izzette/go-safeconcurrency/api/types"
+	"github.com/Izzette/go-safeconcurrency/examples/ecommerce/state"
+)
+
+// ErrProductNotFound is the error returned when the product is not found
+var ErrProductNotFound = errors.New("product not found")
+
+// ReserveStockEvent attempts to reserve product inventory
+type ReserveStockEvent struct {
+	// ProductID is the ID of the product to reserve
+	ProductID string
+
+	// Quantity is the number of items to reserve
+	Quantity int
+
+	// Err is the error returned from the event
+	Err error
+}
+
+// Dispatch implements [types.Event.Dispatch].
+func (e *ReserveStockEvent) Dispatch(_ types.GenerationID, s *state.ProductStockState) {
+	product := s.GetProduct(e.ProductID)
+	if product == nil {
+		e.Err = ErrProductNotFound
+		return
+	}
+
+	availableStock := product.Available()
+	if availableStock < e.Quantity {
+		e.Err = fmt.Errorf("insufficient stock for %s", e.ProductID)
+		return
+	}
+	product.Reserved += e.Quantity
+
+	// Only persist the product changes if the stock is available
+	s.UpdateProduct(e.ProductID, product)
+}
+
+// ReleaseStockEvent returns inventory to available stock
+type ReleaseStockEvent struct {
+	ProductID string
+	Quantity  int
+}
+
+// Dispatch implements [types.Event.Dispatch].
+func (e *ReleaseStockEvent) Execute(_ types.GenerationID, s *state.ProductStockState) {
+	product := s.GetProduct(e.ProductID)
+	if product == nil {
+		fmt.Printf("ERROR: %v\n", ErrProductNotFound)
+		return
+	}
+
+	if product.Reserved < e.Quantity {
+		panic("cannot release more stock than reserved")
+	}
+	product.Reserved -= e.Quantity
+
+	// Save back to the state in a Copy-on-Write fashion
+	s.UpdateProduct(e.ProductID, product)
+}

--- a/examples/ecommerce/server.go
+++ b/examples/ecommerce/server.go
@@ -1,0 +1,331 @@
+package ecommerce
+
+import (
+	"encoding/json"
+	"mime"
+	"net/http"
+	"sync"
+
+	"github.com/Izzette/go-safeconcurrency/api/types"
+	"github.com/Izzette/go-safeconcurrency/eventloop"
+	"github.com/Izzette/go-safeconcurrency/examples/ecommerce/events"
+	"github.com/Izzette/go-safeconcurrency/examples/ecommerce/state"
+)
+
+// EcommerceServer manages inventory and users
+// It uses event loops to manage product stock and user actions
+// It responds to the following API requests:
+//
+//   - GET api/product/?product_id → Product # Display product details
+//   - POST api/product/reserve?product_id&user_id {quantity: int} # Add or remove items from the cart
+//   - GET api/user/cart?user_id → map[string]int # Display the content of the cart
+//   - POST api/user/order?user_id → Order # Start the checkout process (create order)
+//   - GET api/user/order?user_id&order_id → Order # Display order details
+//   - POST api/user/order/status?user_id&order_id {status: string} # Updating order status
+type EcommerceServer struct {
+	stockLoop types.EventLoop[state.ProductStockState]
+	userLoops *sync.Map // userID -> user EventLoop
+	mux       *http.ServeMux
+}
+
+// NewEcommerceServer initializes the server with the initial stock.
+func NewEcommerceServer(initialStock map[string]*state.Product) *EcommerceServer {
+	stockState := state.NewProductStockState(initialStock)
+
+	server := &EcommerceServer{
+		stockLoop: eventloop.New[state.ProductStockState](stockState),
+		userLoops: &sync.Map{},
+		mux:       http.NewServeMux(),
+	}
+
+	server.mux.HandleFunc("/api/product", server.HandleProduct)
+	server.mux.HandleFunc("/api/product/reserve", server.HandleProductReservation)
+	server.mux.HandleFunc("/api/user/cart", server.HandleUserCart)
+	server.mux.HandleFunc("/api/user/order/status", server.HandleUserOrderStatus)
+	server.mux.HandleFunc("/api/user/order", server.HandleUserOrder)
+
+	return server
+}
+
+// GetStockLoop returns the event loop for managing product stock
+func (s *EcommerceServer) GetUserLoop(userID string) types.EventLoop[state.UserState] {
+	newLoop := eventloop.New(state.NewUserState())
+	loadedLoop, loaded := s.userLoops.LoadOrStore(userID, newLoop)
+	if loaded {
+		// Close the new loop if it was not stored in the map.
+		// This is to avoid leaking contexts and goroutines created when the loop was initialized.
+		newLoop.Close()
+	} else {
+		// Start the new loop if it was stored in the map
+		newLoop.Start()
+	}
+
+	// Cast the loaded loop to the correct type.
+	// We are the only ones who store in the map and we only store types.EventLoop[state.UserState].
+	loop, ok := loadedLoop.(types.EventLoop[state.UserState])
+	if !ok {
+		panic("user loop is not of type EventLoop")
+	}
+
+	return loop
+}
+
+// Start starts the server and the stock event loop
+// You must only call this method once, otherwise it will panic.
+func (s *EcommerceServer) Start() {
+	s.stockLoop.Start()
+}
+
+// Stop stops the server and all event loops
+// It is safe to call this method any number of times.
+// You may call this method before or after the server is started.
+func (s *EcommerceServer) Stop() {
+	s.stockLoop.Close()
+	s.userLoops.Range(func(_, value interface{}) bool {
+		loop, ok := value.(types.EventLoop[state.UserState])
+		if !ok {
+			panic("user loop is not of type EventLoop")
+		}
+
+		loop.Close()
+
+		// Keep iteration on the map to close all loops
+		// Returning false would stop the iteration
+		return true
+	})
+}
+
+// ServeHTTP implements the [http.Handler] interface for the server
+func (s *EcommerceServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+// HandleProduct handles product-related requests
+func (s *EcommerceServer) HandleProduct(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	productID := r.URL.Query().Get("product_id")
+	if productID == "" {
+		http.Error(w, "Missing product_id", http.StatusBadRequest)
+		return
+	}
+
+	product := s.stockLoop.Snapshot().State().GetProduct(productID)
+	if product == nil {
+		http.Error(w, "Product not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(product)
+}
+
+// HandleProductReservation handles product reservation requests
+func (s *EcommerceServer) HandleProductReservation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	productID := r.URL.Query().Get("product_id")
+	userID := r.URL.Query().Get("user_id")
+	if productID == "" || userID == "" {
+		http.Error(w, "Missing product_id or user_id", http.StatusBadRequest)
+		return
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	mediatype, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		http.Error(w, "Invalid Content-Type", http.StatusBadRequest)
+		return
+	} else if mediatype != "application/json" {
+		http.Error(w, "Unsupported Content-Type", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var req ReserveProductRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Send the event to reserve stock
+	stockEvent := &events.ReserveStockEvent{
+		ProductID: productID,
+		Quantity:  req.Quantity,
+	}
+	gen, err := s.stockLoop.Send(r.Context(), stockEvent)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Wait for the event to be processed, we have to make sure the stock is reserved before we add to the cart
+	_, err = eventloop.WaitForGeneration(r.Context(), s.stockLoop, gen)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	} else if stockEvent.Err == events.ErrProductNotFound {
+		http.Error(w, "Product not found", http.StatusNotFound)
+		return
+	} else if stockEvent.Err != nil {
+		http.Error(w, stockEvent.Err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Send the event to add to the user's cart
+	userLoop := s.GetUserLoop(userID)
+	addToCartEvent := &events.AddToCartEvent{
+		ProductID: productID,
+		Quantity:  req.Quantity,
+	}
+	_, err = userLoop.Send(r.Context(), addToCartEvent)
+	// No need to wait for this event to be processed, however it may show an inconsistent state if the user checks the
+	// cart before the event is processed.
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleUserCart handles user cart-related requests
+func (s *EcommerceServer) HandleUserCart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID := r.URL.Query().Get("user_id")
+	if userID == "" {
+		http.Error(w, "Missing user_id", http.StatusBadRequest)
+		return
+	}
+
+	// Get the user's cart
+	userLoop := s.GetUserLoop(userID)
+	snapshot := userLoop.Snapshot()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(snapshot.State().GetCart())
+}
+
+// HandleUserOrderStatus updates the order status
+func (s *EcommerceServer) HandleUserOrderStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	userID := r.URL.Query().Get("user_id")
+	orderID := r.URL.Query().Get("order_id")
+	if userID == "" || orderID == "" {
+		http.Error(w, "Missing order_id", http.StatusBadRequest)
+		return
+	}
+
+	userLoop := s.GetUserLoop(userID)
+
+	// Update order status
+	contentType := r.Header.Get("Content-Type")
+	mediatype, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		http.Error(w, "Invalid Content-Type", http.StatusBadRequest)
+		return
+	} else if mediatype != "application/json" {
+		http.Error(w, "Unsupported Content-Type", http.StatusUnsupportedMediaType)
+		return
+	}
+	var req UpdateOrderStatusRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	updateOrderStatusEvent := &events.UpdateOrderStatusEvent{
+		OrderID: orderID,
+		Status:  req.Status,
+	}
+	_, err = userLoop.Send(r.Context(), updateOrderStatusEvent)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// No need to wait for this event to be processed, however it may show an inconsistent state if the user checks the
+	// order status before the event is processed.
+
+	w.WriteHeader(http.StatusOK)
+	return
+}
+
+// HandleUserOrder handles user order-related requests
+func (s *EcommerceServer) HandleUserOrder(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user_id")
+	if userID == "" {
+		http.Error(w, "Missing user_id ", http.StatusBadRequest)
+		return
+	}
+
+	userLoop := s.GetUserLoop(userID)
+	if r.Method == http.MethodPost {
+		// Checkout process
+		checkoutEvent := &events.CheckoutEvent{}
+		gen, err := userLoop.Send(r.Context(), checkoutEvent)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		// Wait for the event to be processed
+		snap, err := eventloop.WaitForGeneration(r.Context(), userLoop, gen)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		} else if checkoutEvent.Err == events.ErrCartEmpty {
+			http.Error(w, "Cart is empty", http.StatusBadRequest)
+			return
+		} else if checkoutEvent.Err != nil {
+			http.Error(w, checkoutEvent.Err.Error(), http.StatusInternalServerError)
+			return
+		}
+		order := snap.State().GetOrder(checkoutEvent.OrderID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(order)
+		return
+	}
+
+	orderID := r.URL.Query().Get("order_id")
+	if orderID == "" {
+		http.Error(w, "Missing order_id", http.StatusBadRequest)
+		return
+	}
+	if r.Method == http.MethodGet {
+		snapshot := userLoop.Snapshot()
+		order := snapshot.State().GetOrder(orderID)
+		if order == nil {
+			http.Error(w, "Order not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(order)
+		return
+	} else {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+}
+
+// ReserveProductRequest represents a request to reserve a product
+type ReserveProductRequest struct {
+	// Quantity is the number of items to reserve
+	Quantity int `json:"quantity"`
+}
+
+// UpdateOrderStatusRequest represents a request to update the order status
+type UpdateOrderStatusRequest struct {
+	// Status is the new status for the order
+	Status string `json:"status"`
+}

--- a/examples/ecommerce/state/product.go
+++ b/examples/ecommerce/state/product.go
@@ -1,0 +1,69 @@
+package state
+
+import "fmt"
+
+// ProductStockState tracks available inventory
+type ProductStockState struct {
+	products map[string]*Product
+}
+
+// NewProductStockState creates a new ProductStockState
+func NewProductStockState(products map[string]*Product) *ProductStockState {
+	return &ProductStockState{
+		products: products,
+	}
+}
+
+// GetProduct gets a product by ID.
+// GetProduct returns a copy of the product, which can be modified without affecting the original or other copies.
+// In order to persist the changes, call [ProductStockState.UpdateProduct] with the product ID and the modified product
+// It returns nil if the product is not found.
+func (s *ProductStockState) GetProduct(productID string) *Product {
+	product, _ := s.products[productID]
+	if product == nil {
+		return nil
+	}
+	// Return a copy of the product to avoid modifying the original
+	productCopy := *product
+	return &productCopy
+}
+
+// UpdateProduct updates a product in the stock state.
+// It uses a Copy-on-Write strategy to avoid modifying the original product.
+func (s *ProductStockState) UpdateProduct(productID string, product *Product) {
+	// Copy the products to avoid modifying the originals
+	products := make(map[string]*Product)
+	for k, v := range s.products {
+		products[k] = v
+	}
+
+	// Update the product
+	products[productID] = product
+
+	// Replace the products map with the updated one
+	s.products = products
+}
+
+// Product represents an item in the store
+type Product struct {
+	// Description is the product description
+	Description string
+
+	// Price is the price of the product
+	Price float64
+
+	// Stock is the number of items available for sale
+	Stock int
+
+	// Reserved is the number of items reserved (in cart) but not yet purchased
+	Reserved int
+}
+
+func (p *Product) String() string {
+	return fmt.Sprintf("Description: %s, Price: %.2f, Available: %d", p.Description, p.Price, p.Stock-p.Reserved)
+}
+
+// Available returns the number of items available for sale
+func (p *Product) Available() int {
+	return p.Stock - p.Reserved
+}

--- a/examples/ecommerce/state/user.go
+++ b/examples/ecommerce/state/user.go
@@ -1,0 +1,117 @@
+package state
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// UserState tracks individual user carts and orders
+type UserState struct {
+	// cart holds the user's cart items
+	cart map[string]int // productID -> quantity
+
+	// orders holds the user's orders
+	orders map[string]*Order // orderID -> Order
+
+	orderSequence int // used to generate unique order IDs
+}
+
+func NewUserState() *UserState {
+	return &UserState{
+		cart:          make(map[string]int),
+		orders:        make(map[string]*Order),
+		orderSequence: 1, // Start order IDs from 1
+	}
+}
+
+func (s *UserState) NextOrderID() string {
+	orderID := strconv.Itoa(s.orderSequence)
+	s.orderSequence++
+	return orderID
+}
+
+// GetCart retrieves the user's cart.
+// GetCart returns a copy of the cart, which can be modified without affecting the original or other copies.
+// In order to persist the changes, call [UserState.UpdateCart] with the product ID and the modified cart
+// It returns an empty map if the cart is empty.
+func (s *UserState) GetCart() map[string]int {
+	// Return a copy of the cart to avoid modifying the original
+	cartCopy := make(map[string]int)
+	for k, v := range s.cart {
+		cartCopy[k] = v
+	}
+	return cartCopy
+}
+
+// UpdateCart updates the user's cart with the given product ID and quantity.
+// UpdateCart uses a Copy-on-Write strategy to avoid modifying the original cart.
+func (s *UserState) UpdateCart(productID string, quantity int) {
+	// Copy the cart to avoid modifying the original
+	cart := make(map[string]int)
+	for k, v := range s.cart {
+		cart[k] = v
+	}
+
+	// Update the cart
+	if quantity == 0 {
+		delete(cart, productID)
+	} else {
+		cart[productID] = quantity
+	}
+
+	// Replace the cart with the updated one
+	s.cart = cart
+}
+
+// ClearCart clears the user's cart.
+// ClearCart creates a new cart to avoid modifying the original cart.
+func (s *UserState) ClearCart() {
+	// Create a new cart to avoid modifying the original
+	s.cart = make(map[string]int)
+}
+
+// GetOrder retrieves an order by ID.
+// GetOrder returns a copy of the order, which can be modified without affecting the original or other copies.
+// In order to persist the changes, call [UserState.UpdateOrder] with the order ID and the modified order
+// It returns nil if the order is not found.
+func (s *UserState) GetOrder(orderID string) *Order {
+	order, exists := s.orders[orderID]
+	if !exists {
+		return nil
+	}
+	// Return a copy of the order to avoid modifying the original
+	orderCopy := *order
+	return &orderCopy
+}
+
+// UpdateOrder updates an order in the user state.
+// It uses a Copy-on-Write strategy to avoid modifying the original order.
+func (s *UserState) UpdateOrder(orderID string, order *Order) {
+	// Copy the orders to avoid modifying the originals
+	orders := make(map[string]*Order)
+	for k, v := range s.orders {
+		orders[k] = v
+	}
+
+	// Update the order
+	orders[orderID] = order
+
+	// Replace the orders map with the updated one
+	s.orders = orders
+}
+
+// Order represents a user's order
+type Order struct {
+	// ID is the unique identifier for the order
+	ID string
+
+	// Items is a map of product IDs to quantities
+	Items map[string]int
+
+	// Status is the order status (e.g., "created", "shipped", "delivered")
+	Status string
+}
+
+func (o *Order) String() string {
+	return fmt.Sprintf("Order ID: %s, Status: %s, Items: %v", o.ID, o.Status, o.Items)
+}

--- a/examples/ecommerceeventloop_test.go
+++ b/examples/ecommerceeventloop_test.go
@@ -1,0 +1,170 @@
+package examples
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/Izzette/go-safeconcurrency/examples/ecommerce"
+	"github.com/Izzette/go-safeconcurrency/examples/ecommerce/state"
+)
+
+// Example_ecommerceEventLoop demonstrates the usage of the event loop to manage inventory and user actions
+// within an e-commerce application.
+// It's implementation is complex, see [github.com/Izzette/go-safeconcurrency/examples/ecommerce] for details.
+func Example_ecommerceEventLoop() {
+	// Initialize server with initial stock
+	server := ecommerce.NewEcommerceServer(map[string]*state.Product{
+		"mittens": {
+			Description: "Warm mittens",
+			Price:       19.99,
+			Stock:       10,
+		},
+		"golden_eggs": {
+			Description: "Golden eggs",
+			Price:       49.99,
+			Stock:       5,
+		},
+		"unobtainium": {
+			Description: "In this economy?!",
+			Price:       999.99,
+			Stock:       0,
+		},
+	})
+	defer server.Stop() // Ensure the server is stopped when done along with all the event loops
+	server.Start()      // Start the server (main product event loop)
+
+	// Create a test server to simulate API requests
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+
+	// Query product
+	resp, err := http.Get(ts.URL + "/api/product?product_id=mittens")
+	if err != nil {
+		fmt.Printf("Error fetching product: %v\n", err)
+		return
+	} else if resp.StatusCode != http.StatusOK {
+		fmt.Printf("Error fetching product: %s\n", resp.Status)
+		return
+	}
+	product := &state.Product{}
+	if err := json.NewDecoder(resp.Body).Decode(product); err != nil {
+		fmt.Printf("Error decoding product: %v\n", err)
+		return
+	}
+
+	// Display product details
+	fmt.Printf("Product: %v\n", product)
+
+	// Adding to cart
+	userID := "bob"
+	reserveRequest := &ecommerce.ReserveProductRequest{
+		Quantity: 3,
+	}
+	reserveRequestBytes, err := json.Marshal(reserveRequest)
+	if err != nil {
+		fmt.Printf("Error marshaling request: %v\n", err)
+		return
+	}
+	resp, err = http.Post(
+		ts.URL+"/api/product/reserve?product_id=mittens&user_id="+url.QueryEscape(userID),
+		"application/json",
+		bytes.NewBuffer(reserveRequestBytes),
+	)
+	if err != nil {
+		fmt.Printf("Error reserving product: %v\n", err)
+	} else if resp.StatusCode != http.StatusOK {
+		fmt.Printf("Error reserving product: %s\n", resp.Status)
+	} else {
+		fmt.Println("Product reserved successfully")
+	}
+
+	// Check remaining stock
+	resp, err = http.Get(ts.URL + "/api/product?product_id=mittens")
+	if err != nil {
+		fmt.Printf("Error fetching product: %v\n", err)
+		return
+	}
+	json.NewDecoder(resp.Body).Decode(&product)
+	fmt.Printf("Product after reservation: %v\n", product)
+
+	// Checkout
+	resp, err = http.Post(
+		ts.URL+"/api/user/order?user_id="+url.QueryEscape(userID),
+		"application/x-empty",
+		bytes.NewReader([]byte{}),
+	)
+	if err != nil {
+		fmt.Printf("Error checking out: %v\n", err)
+		return
+	} else if resp.StatusCode != http.StatusOK {
+		fmt.Printf("Error checking out: %s\n", resp.Status)
+		return
+	}
+	order := &state.Order{}
+	if err := json.NewDecoder(resp.Body).Decode(order); err != nil {
+		fmt.Printf("Error decoding order: %v\n", err)
+		return
+	}
+	fmt.Printf("Checkout started successfully: %v\n", order)
+
+	// Display cart
+	resp, err = http.Get(ts.URL + "/api/user/cart?user_id=" + url.QueryEscape(userID))
+	if err != nil {
+		fmt.Printf("Error fetching cart: %v\n", err)
+		return
+	} else if resp.StatusCode != http.StatusOK {
+		fmt.Printf("Error fetching cart: %s\n", resp.Status)
+		return
+	}
+	cart := make(map[string]int)
+	if err := json.NewDecoder(resp.Body).Decode(&cart); err != nil {
+		fmt.Printf("Error decoding cart: %v\n", err)
+		return
+	}
+	fmt.Printf("Cart: %v\n", cart)
+
+	// Update order status
+	updateOrderStatusRequest := &ecommerce.UpdateOrderStatusRequest{
+		Status: "shipped",
+	}
+	updateOrderStatusRequestBytes, err := json.Marshal(updateOrderStatusRequest)
+	if err != nil {
+		fmt.Printf("Error marshaling request: %v\n", err)
+		return
+	}
+	resp, err = http.Post(
+		ts.URL+"/api/user/order/status?user_id="+url.QueryEscape(userID)+"&order_id="+url.QueryEscape(order.ID),
+		"application/json",
+		bytes.NewBuffer(updateOrderStatusRequestBytes),
+	)
+
+	// Display order status
+	resp, err = http.Get(
+		ts.URL + "/api/user/order?user_id=" + url.QueryEscape(userID) + "&order_id=" + url.QueryEscape(order.ID),
+	)
+	if err != nil {
+		fmt.Printf("Error fetching order status: %v\n", err)
+		return
+	} else if resp.StatusCode != http.StatusOK {
+		fmt.Printf("Error fetching order status: %s\n", resp.Status)
+		return
+	}
+	orderStatus := &state.Order{}
+	if err := json.NewDecoder(resp.Body).Decode(orderStatus); err != nil {
+		fmt.Printf("Error decoding order status: %v\n", err)
+		return
+	}
+	fmt.Printf("Order: %v\n", orderStatus)
+
+	// Output:
+	// Product: Description: Warm mittens, Price: 19.99, Available: 10
+	// Product reserved successfully
+	// Product after reservation: Description: Warm mittens, Price: 19.99, Available: 7
+	// Checkout started successfully: Order ID: 1, Status: created, Items: map[mittens:3]
+	// Cart: map[]
+	// Order: Order ID: 1, Status: shipped, Items: map[mittens:3]
+}

--- a/examples/eventloop.go
+++ b/examples/eventloop.go
@@ -1,0 +1,21 @@
+package examples
+
+import (
+	"fmt"
+
+	"github.com/Izzette/go-safeconcurrency/api/types"
+)
+
+// AppState holds our application state
+type AppState struct {
+	Counter int
+}
+
+// IncrementEvent implements types.Event to modify our state
+type IncrementEvent struct{}
+
+// Dispatch implements [types.Event.Dispatch].
+func (e *IncrementEvent) Dispatch(gen types.GenerationID, s *AppState) {
+	fmt.Printf("<IncrementEvent@%d> current value: %d, next value: %d\n", gen, s.Counter, s.Counter+1)
+	s.Counter++
+}

--- a/examples/eventloop_test.go
+++ b/examples/eventloop_test.go
@@ -1,0 +1,44 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/Izzette/go-safeconcurrency/eventloop"
+)
+
+// Example_eventLoop demonstrates basic event loop usage
+func Example_eventLoop() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialState := &AppState{}
+
+	// Create event loop with 1-event buffer
+	el := eventloop.NewBuffered(
+		initialState,
+		1,
+	)
+	defer el.Close()
+	el.Start()
+
+	// Send our event to the event loop
+	gen, err := el.Send(ctx, &IncrementEvent{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Wait for event processing
+	snap, err := eventloop.WaitForGeneration(ctx, el, gen)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output final state
+	fmt.Printf("Counter: %d\n", snap.State().Counter)
+
+	// Output:
+	// <IncrementEvent@1> current value: 0, next value: 1
+	// Counter: 1
+}

--- a/package.go
+++ b/package.go
@@ -5,5 +5,6 @@
 //   - For types and interfaces: [github.com/Izzette/go-safeconcurrency/api/types]
 //   - For creating generators: [github.com/Izzette/go-safeconcurrency/generator]
 //   - For creating worker pools and tasks: [github.com/Izzette/go-safeconcurrency/workpool]
+//   - For creating event loops: [github.com/Izzette/go-safeconcurrency/eventloop]
 //   - For examples: [github.com/Izzette/go-safeconcurrency/examples]
 package safeconcurrency


### PR DESCRIPTION
* Interface type `types.EventLoop`, `types.Event`, and
  `types.StateSnapshot`
* Type alias `types.GenerationID`
* Factory functions for `types.EventLoop`: `eventloop.New`,
  `eventloop.NewBuffered`
* Helpers `eventloop.WaitForGeneration` and `eventloop.SendAndWait`
* Helper to watch to eventloop state snapshots `eventloop.WatchState`
  and `eventloop.WatchStateFunc`
* Basic example in `examples/eventloop_test.go` and
  `examples/ecommerce.go`
* Advanced example with fake e-commerce server in
  `examples/ecommerceeventloop_test.go` and the `examples/ecommerce`
  module
* Updated documentation
