### PR TITLE
fix(eventloop): improve throughput of event loop

### DIFF
--- a/eventloop/benchmark_test.go
+++ b/eventloop/benchmark_test.go
@@ -11,7 +11,6 @@ import (
 // BenchmarkEventLoopThroughput measures the throughput of the [types.EventLoop].
 // It sends a large number of simple [types.Event] instances, checking that the [types.StateSnapshot] is updated
 // correctly, and measures the time taken.
-// It's performance is heavily tied to the performance of [workpool.Submit].
 func BenchmarkEventLoopThroughput(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/safeconcurrencysync/benchmark_test.go
+++ b/internal/safeconcurrencysync/benchmark_test.go
@@ -1,0 +1,120 @@
+package safeconcurrencysync
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// BenchmarkChannelLock measures the performance of the [ChannelLock.Lock] with a single goroutine and no lock
+// / contention.
+func BenchmarkChannelLock(b *testing.B) {
+	// Create a new ChannelLock
+	lock := NewChannelLock()
+
+	// Reset the timer after initializing the context and lock to avoid measuring setup time.
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		lock.Lock()
+		//nolint:staticcheck // Empty critical section
+		lock.Unlock()
+	}
+
+	// Stop timer before canceling the context to avoid measuring cleanup time.
+	b.StopTimer()
+}
+
+// BenchmarkChannelLockN measures the performance of the [ChannelLock.Lock] with nproc-goroutines all contending for the
+// lock before immediately unlocking it.
+func BenchmarkChannelLockN(b *testing.B) {
+	// Create a new ChannelLock
+	lock := NewChannelLock()
+
+	numCPU := runtime.NumCPU()
+	doneWg := &sync.WaitGroup{} // doneWg signals when all goroutines are done
+	doneWg.Add(numCPU)          // Add the number of goroutines to the wait group
+
+	// Reset the timer after initializing the context and lock to avoid measuring setup time.
+	b.ResetTimer()
+
+	for cpu := 0; cpu < numCPU; cpu++ {
+		go func(cpu int) {
+			defer doneWg.Done()
+
+			for i := cpu; i < b.N; i += numCPU {
+				lock.Lock()
+				//nolint:staticcheck // Empty critical section
+				lock.Unlock()
+			}
+		}(cpu)
+	}
+
+	// Wait for all goroutines to finish
+	doneWg.Wait()
+
+	// Stop timer before canceling the context to avoid measuring cleanup time.
+	b.StopTimer()
+}
+
+// BenchmarkChannelLockWithContext measures the performance of the [ChannelLock.LockWithContextl] with a single
+// goroutine and no lock contention.
+func BenchmarkChannelLockWithContext(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a new ChannelLock
+	lock := NewChannelLock()
+
+	// Reset the timer after initializing the context and lock to avoid measuring setup time.
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := lock.LockWithContext(ctx); err != nil {
+			b.Errorf("Expected nil error, but got %v", err)
+		}
+		lock.Unlock()
+	}
+
+	// Stop timer before canceling the context to avoid measuring cleanup time.
+	b.StopTimer()
+}
+
+// BenchmarkChannelLockWithContextN measures the performance of the [ChannelLock.LockWithContext] with nproc-goroutines
+// all contending for the lock before immediately unlocking it.
+func BenchmarkChannelLockWithContextN(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a new ChannelLock
+	lock := NewChannelLock()
+
+	numCPU := runtime.NumCPU()
+	doneWg := &sync.WaitGroup{} // doneWg signals when all goroutines are done
+	doneWg.Add(numCPU)          // Add the number of goroutines to the wait group
+
+	// Reset the timer after initializing the context and lock to avoid measuring setup time.
+	b.ResetTimer()
+
+	for cpu := 0; cpu < numCPU; cpu++ {
+		go func(cpu int) {
+			defer doneWg.Done()
+
+			for i := cpu; i < b.N; i += numCPU {
+				if err := lock.LockWithContext(ctx); err != nil {
+					b.Errorf("Expected nil error, but got %v", err)
+
+					break
+				}
+				lock.Unlock()
+			}
+		}(cpu)
+	}
+
+	// Wait for all goroutines to finish
+	doneWg.Wait()
+
+	// Stop timer before canceling the context to avoid measuring cleanup time.
+	b.StopTimer()
+}

--- a/internal/safeconcurrencysync/lock.go
+++ b/internal/safeconcurrencysync/lock.go
@@ -1,0 +1,53 @@
+package safeconcurrencysync
+
+import "context"
+
+// ChannelLock is a [sync.Locker] that use a channel to synchronize access allowing [context.Context] cancelation to be
+// respected.
+type ChannelLock struct {
+	channel chan struct{}
+}
+
+// NewChannelLock creates a new [channelLock].
+func NewChannelLock() *ChannelLock {
+	channel := make(chan struct{}, 1)
+	channel <- struct{}{} // Put the "talking-stick" in the channel.
+
+	return &ChannelLock{
+		channel: channel,
+	}
+}
+
+// LockWithContext locks the [ChannelLock].
+// If the [context.Context] is canceled, it returns the [context.Cause].
+// If the [context.Context] is not canceled, it returns nil.
+func (l *ChannelLock) LockWithContext(ctx context.Context) error {
+	// select is not deterministic, and may still obtain the lock even if the context has been canceled.
+	if err := context.Cause(ctx); err != nil {
+		//nolint:wrapcheck
+		return err
+	}
+
+	// Wait for the lock to be available or the context to be canceled, whichever comes first.
+	select {
+	case <-ctx.Done():
+		//nolint:wrapcheck
+		return context.Cause(ctx)
+	case <-l.channel: // Get the "talking-stick" from the channel.
+		return nil
+	}
+}
+
+// Lock implements [sync.Locker.Lock].
+func (l *ChannelLock) Lock() {
+	<-l.channel // Get the "talking-stick" from the channel.
+}
+
+// Unlock implements [sync.Locker.Unlock].
+func (l *ChannelLock) Unlock() {
+	select {
+	case l.channel <- struct{}{}: // Put the "talking-stick" back in the channel.
+	default:
+		panic("unlocking a ChannelLock that is not locked")
+	}
+}

--- a/internal/safeconcurrencysync/lock_test.go
+++ b/internal/safeconcurrencysync/lock_test.go
@@ -1,0 +1,91 @@
+package safeconcurrencysync
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestChannelLock(t *testing.T) {
+	// Create a new ChannelLock
+	lock := NewChannelLock()
+
+	// Lock the CtxLock
+	lock.Lock()
+
+	// Unlock the CtxLock
+	//nolint:staticcheck // Empty critical section
+	lock.Unlock()
+}
+
+func TestChannelLockDoubleUnlock(t *testing.T) {
+	// Create a new ChannelLock
+	lock := NewChannelLock()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic, but got none")
+		}
+	}()
+	// Unlock the ctxLock without locking it first
+	lock.Unlock()
+}
+
+func TestChannelLockCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a new ChannelLock
+	lock := NewChannelLock()
+
+	// Cancel the context
+	cancel()
+
+	// Lock the CtxLock
+	if err := lock.LockWithContext(ctx); err == nil {
+		t.Errorf("Expected error, but got nil")
+	}
+}
+
+func TestChannelLockContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a new ChannelLock
+	lock := NewChannelLock()
+
+	// Lock the CtxLock
+	if err := lock.LockWithContext(ctx); err != nil {
+		t.Errorf("Expected nil error, but got %v", err)
+	}
+
+	// Unlock the CtxLock
+	lock.Unlock()
+}
+
+func TestChannelLockBlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a new ChannelLock
+	lock := NewChannelLock()
+
+	// Lock the CtxLock
+	if err := lock.LockWithContext(ctx); err != nil {
+		t.Errorf("Expected nil error, but got %v", err)
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Try to lock the CtxLock again
+		if err := lock.LockWithContext(ctx); err != nil {
+			t.Errorf("Expected no error, but got %v", err)
+		}
+		lock.Unlock()
+	}()
+
+	lock.Unlock()
+	wg.Wait()
+}


### PR DESCRIPTION
* Using a channel based lock to lock the expected allows respecting context cancelation with better performance than limited concurrency

#### Benchmarks for `ChannelLock`
```
goos: darwin
goarch: arm64
pkg: github.com/Izzette/go-safeconcurrency/internal/safeconcurrencysync
cpu: Apple M1
BenchmarkChannelLock
BenchmarkChannelLock-8               	30248032	        39.62 ns/op
BenchmarkChannelLockN
BenchmarkChannelLockN-8              	 5888913	       201.6 ns/op
BenchmarkChannelLockWithContext
BenchmarkChannelLockWithContext-8    	11855188	       100.9 ns/op
BenchmarkChannelLockWithContextN
BenchmarkChannelLockWithContextN-8   	 3712087	       325.6 ns/op
```

#### Benchmarks for `eventLoop` with limited concurrency workpool to submit event tasks and respond with the expected generation ID. (old)
```
goos: darwin
goarch: arm64
pkg: github.com/Izzette/go-safeconcurrency/eventloop
cpu: Apple M1
BenchmarkEventLoopThroughput
BenchmarkEventLoopThroughput-8   	 1000000	      1154 ns/op
```

#### Benchmarks for `eventLoop` with `ChannelLock` strategy for incrementing expected generation ID. (new)
```
goos: darwin
goarch: arm64
pkg: github.com/Izzette/go-safeconcurrency/eventloop
cpu: Apple M1
BenchmarkEventLoopThroughput
BenchmarkEventLoopThroughput-8   	 2817805	       424.3 ns/op
```